### PR TITLE
Add endpoint for admin to get user goal progress

### DIFF
--- a/lib/cadet_web/admin_controllers/admin_goals_controller.ex
+++ b/lib/cadet_web/admin_controllers/admin_goals_controller.ex
@@ -4,10 +4,17 @@ defmodule CadetWeb.AdminGoalsController do
   use PhoenixSwagger
 
   alias Cadet.Incentives.Goals
+  alias Cadet.Accounts.CourseRegistration
 
   def index(conn, _) do
     course_id = conn.assigns.course_reg.course_id
     render(conn, "index.json", goals: Goals.get(course_id))
+  end
+
+  def index_goals_with_progress(conn, %{"course_reg_id" => course_reg_id}) do
+    course_reg = %CourseRegistration{id: String.to_integer(course_reg_id)}
+
+    render(conn, "index_goals_with_progress.json", goals: Goals.get_with_progress(course_reg))
   end
 
   def bulk_update(conn, %{"goals" => goals}) do
@@ -83,6 +90,17 @@ defmodule CadetWeb.AdminGoalsController do
     security([%{JWT: []}])
 
     response(200, "OK", Schema.array(:Goal))
+    response(401, "Unauthorised")
+    response(403, "Forbidden")
+  end
+
+  swagger_path :index_goals_with_progress do
+    get("/admin/goals/:userid")
+
+    summary("Gets goals and goal progress of a user")
+    security([%{JWT: []}])
+
+    response(200, "OK", Schema.array(:GoalWithProgress))
     response(401, "Unauthorised")
     response(403, "Forbidden")
   end

--- a/lib/cadet_web/admin_views/admin_goals_view.ex
+++ b/lib/cadet_web/admin_views/admin_goals_view.ex
@@ -6,6 +6,10 @@ defmodule CadetWeb.AdminGoalsView do
     render_many(goals, CadetWeb.AdminGoalsView, "goal.json", as: :goal)
   end
 
+  def render("index_goals_with_progress.json", %{goals: goals}) do
+    render_many(goals, CadetWeb.AdminGoalsView, "goal_with_progress.json", as: :goal)
+  end
+
   def render("goal.json", %{goal: goal}) do
     transform_map_for_view(goal, %{
       uuid: :uuid,
@@ -13,6 +17,26 @@ defmodule CadetWeb.AdminGoalsView do
       targetCount: :target_count,
       type: :type,
       meta: :meta
+    })
+  end
+
+  def render("goal_with_progress.json", %{goal: goal}) do
+    transform_map_for_view(goal, %{
+      uuid: :uuid,
+      text: :text,
+      count: fn
+        %{progress: [%{count: count}]} -> count
+        _ -> 0
+      end,
+      completed: fn
+        %{progress: [%{completed: completed}]} -> completed
+        _ -> false
+      end,
+      targetCount: :target_count,
+      type: :type,
+      meta: :meta,
+      achievementUuids:
+        &Enum.map(&1.achievements, fn achievement -> achievement.achievement_uuid end)
     })
   end
 end

--- a/lib/cadet_web/router.ex
+++ b/lib/cadet_web/router.ex
@@ -140,6 +140,7 @@ defmodule CadetWeb.Router do
 
     get("/goals", AdminGoalsController, :index)
     put("/goals", AdminGoalsController, :bulk_update)
+    get("/goals/:course_reg_id", AdminGoalsController, :index_goals_with_progress)
     put("/goals/:uuid", AdminGoalsController, :update)
     delete("/goals/:uuid", AdminGoalsController, :delete)
 

--- a/lib/cadet_web/router.ex
+++ b/lib/cadet_web/router.ex
@@ -132,6 +132,7 @@ defmodule CadetWeb.Router do
     put("/users", AdminUserController, :upsert_users_and_groups)
     put("/users/:course_reg_id/role", AdminUserController, :update_role)
     delete("/users/:course_reg_id", AdminUserController, :delete_user)
+    get("/users/:course_reg_id/goals", AdminGoalsController, :index_goals_with_progress)
     post("/users/:course_reg_id/goals/:uuid/progress", AdminGoalsController, :update_progress)
 
     put("/achievements", AdminAchievementsController, :bulk_update)
@@ -140,7 +141,6 @@ defmodule CadetWeb.Router do
 
     get("/goals", AdminGoalsController, :index)
     put("/goals", AdminGoalsController, :bulk_update)
-    get("/goals/:course_reg_id", AdminGoalsController, :index_goals_with_progress)
     put("/goals/:uuid", AdminGoalsController, :update)
     delete("/goals/:uuid", AdminGoalsController, :delete)
 

--- a/test/cadet_web/admin_controllers/admin_goals_controller_test.exs
+++ b/test/cadet_web/admin_controllers/admin_goals_controller_test.exs
@@ -4,7 +4,7 @@ defmodule CadetWeb.AdminGoalsControllerTest do
   import Cadet.TestEntityHelper
 
   alias Cadet.Repo
-  alias Cadet.Incentives.{Goal, Goals}
+  alias Cadet.Incentives.{Goal, Goals, GoalProgress}
   alias CadetWeb.AdminGoalsController
   alias Ecto.UUID
 
@@ -34,6 +34,56 @@ defmodule CadetWeb.AdminGoalsControllerTest do
 
       assert goal_json_literal(5) = resp_goal
       assert resp_goal["uuid"] == goal.uuid
+    end
+
+    @tag authenticate: :student
+    test "403 for student", %{conn: conn} do
+      course_id = conn.assigns.course_id
+
+      conn
+      |> get(build_path(course_id))
+      |> response(403)
+    end
+
+    test "401 if unauthenticated", %{conn: conn} do
+      course = insert(:course)
+
+      conn
+      |> get(build_path(course.id))
+      |> response(401)
+    end
+  end
+
+  describe "GET v2/courses/:course_id/admin/goals/:userid" do
+    @tag authenticate: :staff
+    test "succeeds for staff", %{conn: conn} do
+      course = conn.assigns.test_cr.course
+
+      {:ok, g} =
+        %Goal{course_id: course.id, uuid: UUID.generate()}
+        |> Map.merge(goal_literal(5))
+        |> Repo.insert()
+
+      course_reg = insert(:course_registration, %{course: course, role: :student})
+
+      {:ok, p} =
+        %GoalProgress{
+          goal_uuid: g.uuid,
+          course_reg_id: course_reg.id,
+          count: 123,
+          completed: true
+        }
+        |> Repo.insert()
+
+      [resp_goal] =
+        conn
+        |> get(build_path(course.id, course_reg.id))
+        |> json_response(200)
+
+      assert goal_json_literal(5) = resp_goal
+      assert resp_goal["uuid"] == g.uuid
+      assert resp_goal["count"] == p.count
+      assert resp_goal["completed"] == p.completed
     end
 
     @tag authenticate: :student

--- a/test/cadet_web/admin_controllers/admin_goals_controller_test.exs
+++ b/test/cadet_web/admin_controllers/admin_goals_controller_test.exs
@@ -54,7 +54,7 @@ defmodule CadetWeb.AdminGoalsControllerTest do
     end
   end
 
-  describe "GET v2/courses/:course_id/admin/goals/:userid" do
+  describe "GET v2/courses/:course_id/admin/users/:course_reg_id/goals" do
     @tag authenticate: :staff
     test "succeeds for staff", %{conn: conn} do
       course = conn.assigns.test_cr.course
@@ -77,7 +77,7 @@ defmodule CadetWeb.AdminGoalsControllerTest do
 
       [resp_goal] =
         conn
-        |> get(build_path(course.id, course_reg.id))
+        |> get(build_user_goals_path(course.id, course_reg.id))
         |> json_response(200)
 
       assert goal_json_literal(5) = resp_goal
@@ -314,5 +314,9 @@ defmodule CadetWeb.AdminGoalsControllerTest do
 
   defp build_path(course_id, uuid, course_reg_id) do
     "/v2/courses/#{course_id}/admin/users/#{course_reg_id}/goals/#{uuid}/progress/"
+  end
+
+  defp build_user_goals_path(course_id, course_reg_id) do
+    "/v2/courses/#{course_id}/admin/users/#{course_reg_id}/goals"
   end
 end


### PR DESCRIPTION
<del>get(/v2/courses/:course_id/admin/goals/:course_reg_id)</del> get(/v2/courses/:course_id/admin/users/:course_reg_id/goals) retrieves the goal progress of the specified user.

Admin goals controller and view updated to support this endpoint. Swagger documentation and tests also updated.

Should not be merged until after yanyu branch merges