### PR TITLE
Remove rank from contest voting

### DIFF
--- a/lib/cadet/assessments/submission_votes.ex
+++ b/lib/cadet/assessments/submission_votes.ex
@@ -6,7 +6,7 @@ defmodule Cadet.Assessments.SubmissionVotes do
   alias Cadet.Assessments.{Question, Submission}
 
   schema "submission_votes" do
-    field(:rank, :integer)
+    field(:score, :integer)
 
     belongs_to(:voter, CourseRegistration)
     belongs_to(:submission, Submission)
@@ -15,7 +15,7 @@ defmodule Cadet.Assessments.SubmissionVotes do
   end
 
   @required_fields ~w(voter_id submission_id question_id)a
-  @optional_fields ~w(rank)a
+  @optional_fields ~w(score)a
 
   def changeset(submission_vote, params) do
     submission_vote

--- a/lib/cadet/jobs/autograder/grading_job.ex
+++ b/lib/cadet/jobs/autograder/grading_job.ex
@@ -141,7 +141,7 @@ defmodule Cadet.Autograder.GradingJob do
       |> join(:inner, [s], sv in SubmissionVotes,
         on: sv.voter_id == s.student_id and sv.question_id == ^question.id
       )
-      |> where([_, sv], is_nil(sv.rank))
+      |> where([_, sv], is_nil(sv.score))
       |> Repo.exists?()
 
     xp = if is_nil_entries, do: 0, else: question.max_xp

--- a/lib/cadet_web/views/assessments_helpers.ex
+++ b/lib/cadet_web/views/assessments_helpers.ex
@@ -129,7 +129,7 @@ defmodule CadetWeb.AssessmentsHelpers do
     transform_map_for_view(entry, %{
       submission_id: :submission_id,
       answer: :answer,
-      rank: :rank
+      score: :score
     })
   end
 
@@ -140,7 +140,7 @@ defmodule CadetWeb.AssessmentsHelpers do
         answer: :answer,
         student_name: :student_name
       }),
-      "score",
+      "relative_score",
       Float.round(leaderboard_ans.relative_score, 2)
     )
   end

--- a/lib/cadet_web/views/assessments_helpers.ex
+++ b/lib/cadet_web/views/assessments_helpers.ex
@@ -140,7 +140,7 @@ defmodule CadetWeb.AssessmentsHelpers do
         answer: :answer,
         student_name: :student_name
       }),
-      "relative_score",
+      "final_score",
       Float.round(leaderboard_ans.relative_score, 2)
     )
   end

--- a/priv/repo/migrations/20210908024720_rename_rank_to_score.exs
+++ b/priv/repo/migrations/20210908024720_rename_rank_to_score.exs
@@ -1,0 +1,7 @@
+defmodule Cadet.Repo.Migrations.RenameRankToScore do
+  use Ecto.Migration
+
+  def change do
+    rename(table(:submission_votes), :rank, to: :score)
+  end
+end

--- a/test/cadet/assessments/assessments_test.exs
+++ b/test/cadet/assessments/assessments_test.exs
@@ -301,7 +301,7 @@ defmodule Cadet.AssessmentsTest do
               fn {submission, index} ->
                 insert(
                   :submission_vote,
-                  rank: index + 1,
+                  score: 10 - index,
                   voter: student,
                   submission: submission,
                   question: voting_question
@@ -466,7 +466,7 @@ defmodule Cadet.AssessmentsTest do
               fn {submission, index} ->
                 insert(
                   :submission_vote,
-                  rank: index + 1,
+                  score: 10 - index,
                   voter: student,
                   submission: submission,
                   question: current_question
@@ -485,7 +485,7 @@ defmodule Cadet.AssessmentsTest do
               fn {submission, index} ->
                 insert(
                   :submission_vote,
-                  rank: index + 1,
+                  score: 10 - index,
                   voter: student,
                   submission: submission,
                   question: yesterday_question
@@ -504,7 +504,7 @@ defmodule Cadet.AssessmentsTest do
               fn {submission, index} ->
                 insert(
                   :submission_vote,
-                  rank: index + 1,
+                  score: 10 - index,
                   voter: student,
                   submission: submission,
                   question: past_question

--- a/test/cadet/assessments/submission_votes_test.exs
+++ b/test/cadet/assessments/submission_votes_test.exs
@@ -64,7 +64,7 @@ defmodule Cadet.Assessments.SubmissionVotesTest do
     test "invalid changeset unique constraint", %{
       valid_params: params
     } do
-      params = Map.put(params, :rank, 2)
+      params = Map.put(params, :score, 2)
       first_entry = SubmissionVotes.changeset(%SubmissionVotes{}, params)
       {:ok, _} = Repo.insert(first_entry)
       new_submission = insert(:submission)

--- a/test/cadet/jobs/autograder/grading_job_test.exs
+++ b/test/cadet/jobs/autograder/grading_job_test.exs
@@ -586,7 +586,7 @@ defmodule Cadet.Autograder.GradingJobTest do
           answers =
             for question <- questions do
               case Enum.random(0..1) do
-                0 -> insert(:submission_vote, %{voter: student, question: question, rank: 1})
+                0 -> insert(:submission_vote, %{voter: student, question: question, score: 1})
                 1 -> insert(:submission_vote, %{voter: student, question: question})
               end
 
@@ -614,7 +614,7 @@ defmodule Cadet.Autograder.GradingJobTest do
           SubmissionVotes
           |> where(voter_id: ^student.id)
           |> where(question_id: ^question.id)
-          |> where([sv], is_nil(sv.rank))
+          |> where([sv], is_nil(sv.score))
           |> Repo.exists?()
 
         answer_db = Repo.get(Answer, answer.id)

--- a/test/cadet_web/controllers/answer_controller_test.exs
+++ b/test/cadet_web/controllers/answer_controller_test.exs
@@ -70,13 +70,13 @@ defmodule CadetWeb.AnswerControllerTest do
         voting_conn =
           post(conn, build_url(course_id, voting_question.id), %{
             answer: [
-              %{"answer" => "hello world", "submission_id" => contest_submission.id, "rank" => 3}
+              %{"answer" => "hello world", "submission_id" => contest_submission.id, "score" => 3}
             ]
           })
 
         assert response(voting_conn, 200) =~ "OK"
-        rank = get_rank_for_submission_vote(voting_question, course_reg, contest_submission)
-        assert rank == 3
+        score = get_score_for_submission_vote(voting_question, course_reg, contest_submission)
+        assert score == 3
       end
 
       @tag authenticate: role
@@ -120,7 +120,7 @@ defmodule CadetWeb.AnswerControllerTest do
         voting_conn =
           post(conn, build_url(course_id, voting_question.id), %{
             answer: [
-              %{"answer" => "hello world", "submission_id" => contest_submission.id, "rank" => 3}
+              %{"answer" => "hello world", "submission_id" => contest_submission.id, "score" => 3}
             ]
           })
 
@@ -129,14 +129,14 @@ defmodule CadetWeb.AnswerControllerTest do
         updated_voting_conn =
           post(conn, build_url(course_id, voting_question.id), %{
             answer: [
-              %{"answer" => "hello world", "submission_id" => contest_submission.id, "rank" => 5}
+              %{"answer" => "hello world", "submission_id" => contest_submission.id, "score" => 5}
             ]
           })
 
         assert response(updated_voting_conn, 200) =~ "OK"
 
-        rank = get_rank_for_submission_vote(voting_question, course_reg, contest_submission)
-        assert rank == 5
+        score = get_score_for_submission_vote(voting_question, course_reg, contest_submission)
+        assert score == 5
       end
 
       @tag authenticate: role
@@ -161,7 +161,7 @@ defmodule CadetWeb.AnswerControllerTest do
 
         post(conn, build_url(course_id, voting_question.id), %{
           answer: [
-            %{"answer" => "hello world", "submission_id" => contest_submission.id, "rank" => 3}
+            %{"answer" => "hello world", "submission_id" => contest_submission.id, "score" => 3}
           ]
         })
 
@@ -253,7 +253,7 @@ defmodule CadetWeb.AnswerControllerTest do
               %{
                 "answer" => "hello world",
                 "submission_id" => contest_submission.id,
-                "rank" => "a"
+                "score" => "a"
               }
             ]
           })
@@ -263,7 +263,7 @@ defmodule CadetWeb.AnswerControllerTest do
       end
 
       @tag authenticate: role
-      test "update duplicate rank in submission_votes is unsuccessful", %{
+      test "update duplicate score in submission_votes is unsuccessful", %{
         conn: conn,
         voting_question: voting_question
       } do
@@ -277,14 +277,14 @@ defmodule CadetWeb.AnswerControllerTest do
           voter_id: course_reg.id,
           question_id: voting_question.id,
           submission_id: first_contest_submission.id,
-          rank: 1
+          score: 1
         })
 
         Repo.insert(%SubmissionVotes{
           voter_id: course_reg.id,
           question_id: voting_question.id,
           submission_id: second_contest_submission.id,
-          rank: 2
+          score: 2
         })
 
         voting_conn =
@@ -293,12 +293,12 @@ defmodule CadetWeb.AnswerControllerTest do
               %{
                 "answer" => "hello world",
                 "submission_id" => first_contest_submission.id,
-                "rank" => 3
+                "score" => 3
               },
               %{
                 "answer" => "hello world",
                 "submission_id" => second_contest_submission.id,
-                "rank" => 3
+                "score" => 3
               }
             ]
           })
@@ -393,12 +393,12 @@ defmodule CadetWeb.AnswerControllerTest do
     end
   end
 
-  defp get_rank_for_submission_vote(question, course_reg, submission) do
+  defp get_score_for_submission_vote(question, course_reg, submission) do
     SubmissionVotes
     |> where(question_id: ^question.id)
     |> where(voter_id: ^course_reg.id)
     |> where(submission_id: ^submission.id)
-    |> select([sv], sv.rank)
+    |> select([sv], sv.score)
     |> Repo.one()
   end
 end

--- a/test/cadet_web/controllers/assessments_controller_test.exs
+++ b/test/cadet_web/controllers/assessments_controller_test.exs
@@ -435,7 +435,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
                 %{
                   "submission_id" => answer.submission.id,
                   "answer" => %{"code" => answer.answer.code},
-                  "rank" => nil
+                  "score" => nil
                 }
               end)
             end)


### PR DESCRIPTION
Remove the concept of rank from contest voting. The scoring for voting is now 1(worst) to 10 (best). 

Should be tested with the frontend PR.