### PR TITLE
Add contest leaderboard hiding

### DIFF
--- a/lib/cadet/assessments/question_types/voting_question.ex
+++ b/lib/cadet/assessments/question_types/voting_question.ex
@@ -10,9 +10,10 @@ defmodule Cadet.Assessments.QuestionTypes.VotingQuestion do
     field(:prepend, :string, default: "")
     field(:template, :string)
     field(:contest_number, :string)
+    field(:reveal_hours, :integer)
   end
 
-  @required_fields ~w(content contest_number)a
+  @required_fields ~w(content contest_number reveal_hours)a
   @optional_fields ~w(prepend template)a
 
   def changeset(question, params \\ %{}) do

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -85,7 +85,6 @@ defmodule Cadet.Updater.XMLParser do
       |> xpath(
         ~x"//TASK"e,
         access: ~x"./@access"s |> transform_by(&process_access/1),
-        # type: ~x"./@kind"s |> transform_by(&change_quest_to_sidequest/1),
         title: ~x"./@title"s,
         number: ~x"./@number"s,
         story: ~x"./@story"s,
@@ -259,7 +258,8 @@ defmodule Cadet.Updater.XMLParser do
       entity
       |> xpath(
         ~x"./VOTING"e,
-        contest_number: ~x"./@assessment_number"s
+        contest_number: ~x"./@assessment_number"s,
+        reveal_hours: ~x"./@reveal_hours"i
       )
     )
   end

--- a/priv/repo/migrations/20210915125021_add_reveal_hours.exs
+++ b/priv/repo/migrations/20210915125021_add_reveal_hours.exs
@@ -1,0 +1,7 @@
+defmodule Cadet.Repo.Migrations.AddRevealHours do
+  use Ecto.Migration
+
+  def change do
+    execute("update questions set question = question || jsonb_build_object('reveal_hours', 48)")
+  end
+end

--- a/test/cadet/assessments/assessments_test.exs
+++ b/test/cadet/assessments/assessments_test.exs
@@ -74,7 +74,8 @@ defmodule Cadet.AssessmentsTest do
           library: build(:library),
           question: %{
             content: Faker.Pokemon.name(),
-            contest_number: assessment.number
+            contest_number: assessment.number,
+            reveal_hours: 48
           }
         },
         assessment.id

--- a/test/cadet/assessments/question_test.exs
+++ b/test/cadet/assessments/question_test.exs
@@ -38,7 +38,8 @@ defmodule Cadet.Assessments.QuestionTest do
       library: build(:library),
       question: %{
         content: Faker.Pokemon.name(),
-        contest_number: assessment.number
+        contest_number: assessment.number,
+        reveal_hours: 48
       }
     }
 

--- a/test/cadet/assessments/question_types/voting_question_test.exs
+++ b/test/cadet/assessments/question_types/voting_question_test.exs
@@ -8,7 +8,8 @@ defmodule Cadet.Assessments.QuestionTypes.VotingQuestionTest do
       assert_changeset(
         %{
           content: "content",
-          contest_number: "C4"
+          contest_number: "C4",
+          reveal_hours: 48
         },
         :valid
       )

--- a/test/factories/assessments/question_factory.ex
+++ b/test/factories/assessments/question_factory.ex
@@ -92,7 +92,8 @@ defmodule Cadet.Assessments.QuestionFactory do
             content: Faker.Pokemon.name(),
             prepend: Faker.Pokemon.location(),
             template: Faker.Lorem.Shakespeare.as_you_like_it(),
-            contest_number: contest_assessment.number
+            contest_number: contest_assessment.number,
+            reveal_hours: 48
           }
         }
       end
@@ -104,7 +105,8 @@ defmodule Cadet.Assessments.QuestionFactory do
           content: Faker.Pokemon.name(),
           prepend: Faker.Pokemon.location(),
           template: Faker.Lorem.Shakespeare.as_you_like_it(),
-          contest_number: contest_assessment.number
+          contest_number: contest_assessment.number,
+          reveal_hours: 48
         }
       end
     end

--- a/test/support/xml_generator.ex
+++ b/test/support/xml_generator.ex
@@ -154,7 +154,11 @@ defmodule Cadet.Test.XMLGenerator do
 
         template_field = [template(question.question.template)]
 
-        voting_field = voting(%{assessment_number: question.question.contest_number})
+        voting_field =
+          voting(%{
+            reveal_hours: question.question.reveal_hours,
+            assessment_number: question.question.contest_number
+          })
 
         [
           snippet(prepend_field ++ template_field)
@@ -163,7 +167,7 @@ defmodule Cadet.Test.XMLGenerator do
   end
 
   defp voting(raw_attr) do
-    {"VOTING", map_permit_keys(raw_attr, ~w(assessment_number)a)}
+    {"VOTING", map_permit_keys(raw_attr, ~w(assessment_number reveal_hours)a)}
   end
 
   defp deployment(raw_attrs, children) do


### PR DESCRIPTION
`reveal_hours` is to be specified in the xml `VOTING` tag to set the reveal hours of the leaderboard relative to the assessment close time.