### PR TITLE
Removing unique score constraint for contest entries from backend (in preparation for frontend PR)

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -703,8 +703,9 @@ defmodule Cadet.Assessments do
       {:error, :race_condition} ->
         {:error, {:internal_server_error, "Please try again later."}}
 
-      {:error, :vote_not_unique} ->
-        {:error, {:bad_request, "Invalid vote or vote is not unique! Vote is not saved."}}
+      # Description changed from :vote_not_unique and corresponding message changed.
+      {:error, :invalid_vote} ->
+        {:error, {:bad_request, "Invalid vote! Vote is not saved."}}
 
       _ ->
         {:error, {:bad_request, "Missing or invalid parameter(s)"}}
@@ -1012,7 +1013,7 @@ defmodule Cadet.Assessments do
   Computes rolling leaderboard for contest votes that are still open.
   """
   def update_rolling_contest_leaderboards do
-    # 115 = 2 hours - 5 minutes
+    # 115 = 2 hours - 5 minutes is default.
     if Log.log_execution("update_rolling_contest_leaderboards", Timex.Duration.from_minutes(115)) do
       Logger.info("Started update_rolling_contest_leaderboards")
 
@@ -1630,7 +1631,8 @@ defmodule Cadet.Assessments do
     |> Repo.transaction()
     |> case do
       {:ok, _result} -> {:ok, nil}
-      {:error, _name, _changset, _error} -> {:error, :vote_not_unique}
+      # error type has been changed to :invalid_vote as a non-unique score will no longer cause an error.
+      {:error, _name, _changeset, _error} -> {:error, :invalid_vote}
     end
   end
 

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -703,7 +703,6 @@ defmodule Cadet.Assessments do
       {:error, :race_condition} ->
         {:error, {:internal_server_error, "Please try again later."}}
 
-      # Description changed from :vote_not_unique and corresponding message changed.
       {:error, :invalid_vote} ->
         {:error, {:bad_request, "Invalid vote! Vote is not saved."}}
 
@@ -1631,7 +1630,6 @@ defmodule Cadet.Assessments do
     |> Repo.transaction()
     |> case do
       {:ok, _result} -> {:ok, nil}
-      # error type has been changed to :invalid_vote
       {:error, _name, _changeset, _error} -> {:error, :invalid_vote}
     end
   end

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1631,7 +1631,7 @@ defmodule Cadet.Assessments do
     |> Repo.transaction()
     |> case do
       {:ok, _result} -> {:ok, nil}
-      # error type has been changed to :invalid_vote as a non-unique score will no longer cause an error.
+      # error type has been changed to :invalid_vote
       {:error, _name, _changeset, _error} -> {:error, :invalid_vote}
     end
   end

--- a/lib/cadet/assessments/submission_votes.ex
+++ b/lib/cadet/assessments/submission_votes.ex
@@ -25,6 +25,6 @@ defmodule Cadet.Assessments.SubmissionVotes do
     |> foreign_key_constraint(:voter_id)
     |> foreign_key_constraint(:submission_id)
     |> foreign_key_constraint(:question_id)
-    |> unique_constraint(:vote_not_unique, name: :unique_score)
+    # |> unique_constraint(:unique, name: :unique_score) (Unique constraint removed)
   end
 end

--- a/lib/cadet/assessments/submission_votes.ex
+++ b/lib/cadet/assessments/submission_votes.ex
@@ -17,6 +17,7 @@ defmodule Cadet.Assessments.SubmissionVotes do
   @required_fields ~w(voter_id submission_id question_id)a
   @optional_fields ~w(score)a
 
+  # |> unique_constraint(:unique, name: :unique_score) (Unique constraint removed)
   def changeset(submission_vote, params) do
     submission_vote
     |> cast(params, @required_fields ++ @optional_fields)
@@ -25,6 +26,5 @@ defmodule Cadet.Assessments.SubmissionVotes do
     |> foreign_key_constraint(:voter_id)
     |> foreign_key_constraint(:submission_id)
     |> foreign_key_constraint(:question_id)
-  # |> unique_constraint(:unique, name: :unique_score) (Unique constraint removed)
   end
 end

--- a/lib/cadet/assessments/submission_votes.ex
+++ b/lib/cadet/assessments/submission_votes.ex
@@ -25,6 +25,6 @@ defmodule Cadet.Assessments.SubmissionVotes do
     |> foreign_key_constraint(:voter_id)
     |> foreign_key_constraint(:submission_id)
     |> foreign_key_constraint(:question_id)
-    # |> unique_constraint(:unique, name: :unique_score) (Unique constraint removed)
+  # |> unique_constraint(:unique, name: :unique_score) (Unique constraint removed)
   end
 end

--- a/lib/cadet/assessments/submission_votes.ex
+++ b/lib/cadet/assessments/submission_votes.ex
@@ -17,7 +17,7 @@ defmodule Cadet.Assessments.SubmissionVotes do
   @required_fields ~w(voter_id submission_id question_id)a
   @optional_fields ~w(score)a
 
-  # |> unique_constraint(:unique, name: :unique_score) (Unique constraint removed)
+  # There is no unique constraint for contest vote scores.
   def changeset(submission_vote, params) do
     submission_vote
     |> cast(params, @required_fields ++ @optional_fields)

--- a/priv/repo/migrations/20230331010500_remove_unique_score_constraint.exs
+++ b/priv/repo/migrations/20230331010500_remove_unique_score_constraint.exs
@@ -1,0 +1,11 @@
+defmodule Cadet.Repo.Migrations.RemoveUniqueScoreConstraint do
+  use Ecto.Migration
+
+  def up do
+    drop(unique_index(:submission_votes, [:user_id, :question_id, :score], name: :unique_score))
+  end
+
+  def down do
+    create(unique_index(:submission_votes, [:user_id, :question_id, :score], name: :unique_score))
+  end
+end

--- a/test/cadet/assessments/submission_votes_test.exs
+++ b/test/cadet/assessments/submission_votes_test.exs
@@ -61,21 +61,6 @@ defmodule Cadet.Assessments.SubmissionVotesTest do
       |> assert_changeset_db(:invalid)
     end
 
-    test "invalid changeset unique constraint", %{
-      valid_params: params
-    } do
-      params = Map.put(params, :score, 2)
-      first_entry = SubmissionVotes.changeset(%SubmissionVotes{}, params)
-      {:ok, _} = Repo.insert(first_entry)
-      new_submission = insert(:submission)
-
-      second_entry =
-        first_entry
-        |> Map.delete(:submission_id)
-        |> Map.put(:submission_id, new_submission.id)
-
-      {:error, changeset} = Repo.insert(second_entry)
-      refute changeset.valid?
-    end
+    # Removed test for unique submission vote
   end
 end

--- a/test/cadet/assessments/submission_votes_test.exs
+++ b/test/cadet/assessments/submission_votes_test.exs
@@ -61,6 +61,6 @@ defmodule Cadet.Assessments.SubmissionVotesTest do
       |> assert_changeset_db(:invalid)
     end
 
-    # Removed test for unique submission vote
+    # There is no constraint for unique vote score.
   end
 end

--- a/test/cadet_web/controllers/answer_controller_test.exs
+++ b/test/cadet_web/controllers/answer_controller_test.exs
@@ -259,55 +259,8 @@ defmodule CadetWeb.AnswerControllerTest do
           })
 
         assert response(voting_conn, 400) ==
-                 "Invalid vote or vote is not unique! Vote is not saved."
+                 "Invalid vote! Vote is not saved."
       end
-
-      @tag authenticate: role
-      test "update duplicate score in submission_votes is unsuccessful", %{
-        conn: conn,
-        voting_question: voting_question
-      } do
-        course_reg = conn.assigns.test_cr
-        course_id = conn.assigns.course_id
-
-        first_contest_submission = insert(:submission)
-        second_contest_submission = insert(:submission)
-
-        Repo.insert(%SubmissionVotes{
-          voter_id: course_reg.id,
-          question_id: voting_question.id,
-          submission_id: first_contest_submission.id,
-          score: 1
-        })
-
-        Repo.insert(%SubmissionVotes{
-          voter_id: course_reg.id,
-          question_id: voting_question.id,
-          submission_id: second_contest_submission.id,
-          score: 2
-        })
-
-        voting_conn =
-          post(conn, build_url(course_id, voting_question.id), %{
-            answer: [
-              %{
-                "answer" => "hello world",
-                "submission_id" => first_contest_submission.id,
-                "score" => 3
-              },
-              %{
-                "answer" => "hello world",
-                "submission_id" => second_contest_submission.id,
-                "score" => 3
-              }
-            ]
-          })
-
-        assert response(voting_conn, 400) ==
-                 "Invalid vote or vote is not unique! Vote is not saved."
-      end
-    end
-  end
 
   @tag authenticate: :student
   test "invalid params missing question is unsuccessful", %{

--- a/test/cadet_web/controllers/answer_controller_test.exs
+++ b/test/cadet_web/controllers/answer_controller_test.exs
@@ -261,6 +261,8 @@ defmodule CadetWeb.AnswerControllerTest do
         assert response(voting_conn, 400) ==
                  "Invalid vote! Vote is not saved."
       end
+    end
+  end
 
   @tag authenticate: :student
   test "invalid params missing question is unsuccessful", %{


### PR DESCRIPTION
Aim is to remove unique score checking for contest entries in backend in preparation for our frontend pull request to implement our contest voting tierlist, which accepts non-unique scores as submissions.

Am changing these 5 files:

assessments.ex - removed reference to non-unique submission votes causing an error and changed corresponding error message.
submission_votes_test.exs - removed test for unique votes.
submission_votes.ex - commented out unique score checker (unique_constraint)
Added new migration file 20230331010500_remove_unique_score_constraint.exs - reversible migration that removes the unique score index from the database, such that it can accept non-unique score entries.
answer_controller_test.exs - removed test case that checked for duplicate score, changed test case to check for updated error message in assessments.ex
