### PR TITLE
Update grading json to include student usernames

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1242,6 +1242,7 @@ defmodule Cadet.Assessments do
                  (select
                    cr.id,
                    u.name as "name",
+                   u.username as "username",
                    g.name as "groupName",
                    g.leader_id as "groupLeaderId"
                  from course_registrations cr

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1224,6 +1224,7 @@ defmodule Cadet.Assessments do
                  (select
                    a.id,
                    a.title,
+                   a.number as "assessmentNumber",
                    bool_or(ac.is_manually_graded) as "isManuallyGraded",
                    max(ac.type) as "type",
                    sum(q.max_xp) as "maxXp",

--- a/lib/cadet_web/admin_controllers/admin_grading_controller.ex
+++ b/lib/cadet_web/admin_controllers/admin_grading_controller.ex
@@ -310,6 +310,7 @@ defmodule CadetWeb.AdminGradingController do
           properties do
             id(:integer, "student id", required: true)
             name(:string, "student name", required: true)
+            username(:string, "student username", required: true)
             groupName(:string, "name of student's group")
             groupLeaderId(:integer, "user id of group leader")
           end

--- a/lib/cadet_web/admin_views/admin_grading_view.ex
+++ b/lib/cadet_web/admin_views/admin_grading_view.ex
@@ -10,7 +10,11 @@ defmodule CadetWeb.AdminGradingView do
   def render("grading_info.json", %{answer: answer}) do
     transform_map_for_view(answer, %{
       student:
-        &transform_map_for_view(&1.submission.student, %{name: fn st -> st.user.name end, id: :id}),
+        &transform_map_for_view(&1.submission.student, %{
+          name: fn st -> st.user.name end,
+          id: :id,
+          username: fn st -> st.user.username end
+        }),
       question: &build_grading_question/1,
       solution: &(&1.question.question["solution"] || ""),
       grade: &build_grade/1

--- a/test/cadet_web/admin_controllers/admin_grading_controller_test.exs
+++ b/test/cadet_web/admin_controllers/admin_grading_controller_test.exs
@@ -133,7 +133,8 @@ defmodule CadetWeb.AdminGradingControllerTest do
               "maxXp" => 5000,
               "id" => mission.id,
               "title" => mission.title,
-              "questionCount" => 5
+              "questionCount" => 5,
+              "assessmentNumber" => mission.number
             },
             "status" => Atom.to_string(submission.status),
             "gradedCount" => 5,
@@ -197,7 +198,8 @@ defmodule CadetWeb.AdminGradingControllerTest do
               "maxXp" => 5000,
               "id" => mission.id,
               "title" => mission.title,
-              "questionCount" => 5
+              "questionCount" => 5,
+              "assessmentNumber" => mission.number
             },
             "status" => Atom.to_string(submission.status),
             "gradedCount" => 5,
@@ -798,7 +800,8 @@ defmodule CadetWeb.AdminGradingControllerTest do
               "maxXp" => 5000,
               "id" => mission.id,
               "title" => mission.title,
-              "questionCount" => 5
+              "questionCount" => 5,
+              "assessmentNumber" => mission.number
             },
             "status" => Atom.to_string(submission.status),
             "gradedCount" => 5,
@@ -842,7 +845,8 @@ defmodule CadetWeb.AdminGradingControllerTest do
               "maxXp" => 5000,
               "id" => mission.id,
               "title" => mission.title,
-              "questionCount" => 5
+              "questionCount" => 5,
+              "assessmentNumber" => mission.number
             },
             "status" => Atom.to_string(submission.status),
             "gradedCount" => 5,

--- a/test/cadet_web/admin_controllers/admin_grading_controller_test.exs
+++ b/test/cadet_web/admin_controllers/admin_grading_controller_test.exs
@@ -122,6 +122,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
             "id" => submission.id,
             "student" => %{
               "name" => submission.student.user.name,
+              "username" => submission.student.user.username,
               "id" => submission.student.id,
               "groupName" => submission.student.group.name,
               "groupLeaderId" => submission.student.group.leader_id
@@ -185,6 +186,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
             "id" => submission.id,
             "student" => %{
               "name" => submission.student.user.name,
+              "username" => submission.student.user.username,
               "id" => submission.student.id,
               "groupName" => submission.student.group.name,
               "groupLeaderId" => submission.student.group.leader_id
@@ -291,6 +293,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                 },
                 "student" => %{
                   "name" => &1.submission.student.user.name,
+                  "username" => &1.submission.student.user.username,
                   "id" => &1.submission.student.id
                 }
               }
@@ -338,6 +341,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                 },
                 "student" => %{
                   "name" => &1.submission.student.user.name,
+                  "username" => &1.submission.student.user.username,
                   "id" => &1.submission.student.id
                 }
               }
@@ -380,6 +384,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                 },
                 "student" => %{
                   "name" => &1.submission.student.user.name,
+                  "username" => &1.submission.student.user.username,
                   "id" => &1.submission.student.id
                 },
                 "solution" => ""
@@ -782,6 +787,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
             "id" => submission.id,
             "student" => %{
               "name" => submission.student.user.name,
+              "username" => submission.student.user.username,
               "id" => submission.student.id,
               "groupName" => submission.student.group.name,
               "groupLeaderId" => submission.student.group.leader_id
@@ -825,6 +831,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
             "id" => submission.id,
             "student" => %{
               "name" => submission.student.user.name,
+              "username" => submission.student.user.username,
               "id" => submission.student.id,
               "groupName" => submission.student.group.name,
               "groupLeaderId" => submission.student.group.leader_id
@@ -931,6 +938,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                 },
                 "student" => %{
                   "name" => &1.submission.student.user.name,
+                  "username" => &1.submission.student.user.username,
                   "id" => &1.submission.student.id
                 }
               }
@@ -978,6 +986,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                 },
                 "student" => %{
                   "name" => &1.submission.student.user.name,
+                  "username" => &1.submission.student.user.username,
                   "id" => &1.submission.student.id
                 }
               }
@@ -1020,6 +1029,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                 },
                 "student" => %{
                   "name" => &1.submission.student.user.name,
+                  "username" => &1.submission.student.user.username,
                   "id" => &1.submission.student.id
                 },
                 "solution" => ""


### PR DESCRIPTION
As per title. To facilitate the display of student usernames in the grading table and GradingWorkspace in the frontend.