### PR TITLE
Fix deprecations, caching, update actions workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,23 +30,20 @@ jobs:
       - uses: rlespinasse/github-slug-action@v3.x
       - uses: actions/checkout@v2
       - name: Cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-          restore-keys: |
-            ${{ runner.os }}-mix-
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             _build
             !_build/prod/cadet-0.0.1.tar.gz
-          key: cd-${{ env.GITHUB_REF_SLUG }}-${{ runner.os }}-erlang-${{ env.OTP_VERSION }}-elixir-${{ env.ELIXIR_VERSION }}-${{ github.sha }}
-          restore-keys: |
-            cd-${{ env.GITHUB_REF_SLUG }}-${{ runner.os }}-erlang-${{ env.OTP_VERSION }}-elixir-${{ env.ELIXIR_VERSION }}-
+          # Elixir is smart enough to know what needs to be recompiled automatically
+          key: cd-${{ runner.os }}-erlang-${{ env.OTP_VERSION }}-elixir-${{ env.ELIXIR_VERSION }}
       - name: Setup Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,25 +37,23 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-          restore-keys: |
-            ${{ runner.os }}-mix-
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             _build
             priv/plts
-          key: 1-${{ runner.os }}-erlang-${{ env.OTP_VERSION }}-elixir-${{ env.ELIXIR_VERSION }}-${{ github.sha }}
-          restore-keys: |
-            1-${{ runner.os }}-erlang-${{ env.OTP_VERSION }}-elixir-${{ env.ELIXIR_VERSION }}-
+          # Elixir is smart enough to know what needs to be recompiled
+          key: 1-${{ runner.os }}-erlang-${{ env.OTP_VERSION }}-elixir-${{ env.ELIXIR_VERSION }}
       - name: Setup Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}

--- a/lib/cadet/accounts/accounts.ex
+++ b/lib/cadet/accounts/accounts.ex
@@ -55,9 +55,8 @@ defmodule Cadet.Accounts do
     CourseRegistration
     |> where([cr], cr.course_id == ^course_id)
     |> join(:inner, [cr], u in assoc(cr, :user))
-    |> preload([cr, u], user: u)
     |> join(:left, [cr, u], g in assoc(cr, :group))
-    |> preload([cr, u, g], group: g)
+    |> preload([cr, u, g], user: u, group: g)
     |> get_users_helper(filter)
   end
 

--- a/lib/cadet/application.ex
+++ b/lib/cadet/application.ex
@@ -16,7 +16,7 @@ defmodule Cadet.Application do
       {CadetWeb.Endpoint, []},
       {Phoenix.PubSub, [name: Cadet.PubSub, adapter: Phoenix.PubSub.PG2]},
       # Start your own worker by calling: Cadet.Worker.start_link(arg1, arg2, arg3)
-      # worker(Cadet.Worker, [arg1, arg2, arg3]),
+      # {Cadet.Worker, [arg1, arg2, arg3]},
       # Start the GuardianDB sweeper
       {Guardian.DB.Token.SweeperServer, []},
       # Start the Quantum scheduler

--- a/lib/cadet/application.ex
+++ b/lib/cadet/application.ex
@@ -6,21 +6,21 @@ defmodule Cadet.Application do
   # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
-    import Supervisor.Spec
-
     # Define workers and child supervisors to be supervised
+    # No need to distinguish between workers and supervisors anymore
+    # https://kobrakai.de/kolumne/child-specs-in-elixir/
     children = [
       # Start the Ecto repository
-      supervisor(Cadet.Repo, []),
+      {Cadet.Repo, []},
       # Start the endpoint when the application starts
-      supervisor(CadetWeb.Endpoint, []),
+      {CadetWeb.Endpoint, []},
       {Phoenix.PubSub, [name: Cadet.PubSub, adapter: Phoenix.PubSub.PG2]},
       # Start your own worker by calling: Cadet.Worker.start_link(arg1, arg2, arg3)
       # worker(Cadet.Worker, [arg1, arg2, arg3]),
       # Start the GuardianDB sweeper
-      worker(Guardian.DB.Token.SweeperServer, []),
+      {Guardian.DB.Token.SweeperServer, []},
       # Start the Quantum scheduler
-      worker(Cadet.Jobs.Scheduler, []),
+      {Cadet.Jobs.Scheduler, []},
       # Start the Oban instance
       {Oban, Application.fetch_env!(:cadet, Oban)}
     ]
@@ -28,7 +28,7 @@ defmodule Cadet.Application do
     children =
       case Application.get_env(:cadet, :openid_connect_providers) do
         nil -> children
-        providers -> children ++ [worker(OpenIDConnect.Worker, [providers])]
+        providers -> children ++ [{OpenIDConnect.Worker, [providers]}]
       end
 
     {:ok, _} = Logger.add_backend(Sentry.LoggerBackend)


### PR DESCRIPTION
Closes #1035.

Migrates away from the deprecated `Supervisor.Spec` notations, as well as some minor changes and improvements to the codebase and workflow.

Intentionally left out some changes to not conflict with #971.