### PR TITLE
Rename contest leaderboard to score leaderboard

### DIFF
--- a/lib/cadet_web/helpers/assessments_helpers.ex
+++ b/lib/cadet_web/helpers/assessments_helpers.ex
@@ -180,7 +180,7 @@ defmodule CadetWeb.AssessmentsHelpers do
           solutionTemplate: "template",
           contestEntries:
             &Enum.map(&1[:contest_entries], fn entry -> build_contest_entry(entry) end),
-          contestLeaderboard:
+          scoreLeaderboard:
             &Enum.map(&1[:contest_leaderboard], fn entry ->
               build_contest_leaderboard_entry(entry)
             end)

--- a/test/cadet_web/admin_controllers/admin_grading_controller_test.exs
+++ b/test/cadet_web/admin_controllers/admin_grading_controller_test.exs
@@ -372,7 +372,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                   "autogradingResults" => &1.autograding_results,
                   "answer" => nil,
                   "contestEntries" => [],
-                  "contestLeaderboard" => []
+                  "scoreLeaderboard" => []
                 },
                 "grade" => %{
                   "xp" => &1.xp,
@@ -1019,7 +1019,7 @@ defmodule CadetWeb.AdminGradingControllerTest do
                   "autogradingResults" => &1.autograding_results,
                   "answer" => nil,
                   "contestEntries" => [],
-                  "contestLeaderboard" => []
+                  "scoreLeaderboard" => []
                 },
                 "grade" => %{
                   "xp" => &1.xp,

--- a/test/cadet_web/controllers/assessments_controller_test.exs
+++ b/test/cadet_web/controllers/assessments_controller_test.exs
@@ -445,7 +445,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
             |> Enum.zip(contests_entries)
             |> Enum.map(fn {question, contest_entries} ->
               question = Map.put(question, "contestEntries", contest_entries)
-              Map.put(question, "contestLeaderboard", [])
+              Map.put(question, "scoreLeaderboard", [])
             end)
 
           expected_questions =
@@ -540,7 +540,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
           |> json_response(200)
           |> Map.get("questions", [])
           |> Enum.find(&(&1["id"] == voting_question.id))
-          |> Map.get("contestLeaderboard")
+          |> Map.get("scoreLeaderboard")
 
         assert resp_leaderboard == expected_leaderboard
       end
@@ -612,7 +612,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
           |> json_response(200)
           |> Map.get("questions", [])
           |> Enum.find(&(&1["id"] == voting_question.id))
-          |> Map.get("contestLeaderboard")
+          |> Map.get("scoreLeaderboard")
 
         assert resp_leaderboard == expected_leaderboard
       end
@@ -672,7 +672,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
         |> json_response(200)
         |> Map.get("questions", [])
         |> Enum.find(&(&1["id"] == voting_question.id))
-        |> Map.get("contestLeaderboard")
+        |> Map.get("scoreLeaderboard")
 
       assert resp_leaderboard == expected_leaderboard
     end


### PR DESCRIPTION
This pull request changes the type of the JSON returned from contestLeaderboard to scoreLeaderboard in order to accompany the  changes in Frontend.

**Type of change**

- [x] Rename contest leaderboard to score leaderboard
- [x]  Update test cases to match