### PR TITLE
Fix Avenger Backlog Notifications

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1589,17 +1589,18 @@ defmodule Cadet.Assessments do
 
     formatted_submissions =
       Enum.map(submissions, fn submission ->
-        student_name =
+        [student_course_id, student_name] =
           CourseRegistration
           |> join(:inner, [cr], u in assoc(cr, :user))
           |> where([cr], cr.id == ^submission.student_id)
-          |> select([cr, u], u.name)
+          |> select([cr, u], [cr.course_id, u.name])
           |> Repo.one()
 
         assessment_title = Repo.get(Assessment, submission.assessment_id).title
 
         %{
           student_name: student_name,
+          student_course_id: student_course_id,
           assessment_title: assessment_title,
           submission_id: submission.id
         }

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1486,14 +1486,15 @@ defmodule Cadet.Assessments do
         as: :asst,
         where: s.status == "submitted",
         where: asst.question_count > ans.graded_count,
-        where: s.student_id in subquery(
-          from(cr in CourseRegistration,
-            join: g in Group,
-            on: cr.group_id == g.id,
-            where: g.leader_id == ^avenger_cr.id,
-            select: cr.id
-          )
-        ) or s.student_id == ^avenger_cr.id,
+        where:
+          s.student_id in subquery(
+            from(cr in CourseRegistration,
+              join: g in Group,
+              on: cr.group_id == g.id,
+              where: g.leader_id == ^avenger_cr.id,
+              select: cr.id
+            )
+          ) or s.student_id == ^avenger_cr.id,
         select: %{
           id: s.id,
           student_id: s.student_id,
@@ -1502,15 +1503,19 @@ defmodule Cadet.Assessments do
       )
 
     submissions = Repo.all(query)
-    formatted_submissions = Enum.map(submissions, fn submission ->
-      student_name = Repo.get(User, submission.student_id).name
-      assessment_title = Repo.get(Assessment, submission.assessment_id).title
-      %{
-        student_name: student_name,
-        assessment_title: assessment_title,
-        submission_id: submission.id
-      }
-    end)
+
+    formatted_submissions =
+      Enum.map(submissions, fn submission ->
+        student_name = Repo.get(User, submission.student_id).name
+        assessment_title = Repo.get(Assessment, submission.assessment_id).title
+
+        %{
+          student_name: student_name,
+          assessment_title: assessment_title,
+          submission_id: submission.id
+        }
+      end)
+
     {:ok, formatted_submissions}
   end
 

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1506,8 +1506,15 @@ defmodule Cadet.Assessments do
 
     formatted_submissions =
       Enum.map(submissions, fn submission ->
-        student_name = CourseRegistration |> join(:inner, [cr], u in assoc(cr, :user)) |> where([cr], cr.id == ^submission.student_id) |> select([cr, u], u.name) |> Repo.one()
+        student_name =
+          CourseRegistration
+          |> join(:inner, [cr], u in assoc(cr, :user))
+          |> where([cr], cr.id == ^submission.student_id)
+          |> select([cr, u], u.name)
+          |> Repo.one()
+
         assessment_title = Repo.get(Assessment, submission.assessment_id).title
+
         %{
           student_name: student_name,
           assessment_title: assessment_title,

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1506,9 +1506,8 @@ defmodule Cadet.Assessments do
 
     formatted_submissions =
       Enum.map(submissions, fn submission ->
-        student_name = Repo.get(User, submission.student_id).name
+        student_name = CourseRegistration |> join(:inner, [cr], u in assoc(cr, :user)) |> where([cr], cr.id == ^submission.student_id) |> select([cr, u], u.name) |> Repo.one()
         assessment_title = Repo.get(Assessment, submission.assessment_id).title
-
         %{
           student_name: student_name,
           assessment_title: assessment_title,

--- a/lib/cadet/email.ex
+++ b/lib/cadet/email.ex
@@ -20,6 +20,7 @@ defmodule Cadet.Email do
             )
           )
         end)
+
       base_email()
       |> to(avenger.email)
       |> assign(:avenger_name, avenger.name)
@@ -56,8 +57,8 @@ defmodule Cadet.Email do
     |> put_html_layout({CadetWeb.LayoutView, "email.html"})
   end
 
-    # TODO update this to use frontend url
-    defp build_submission_url(course_id, submission_id) do
-      "https://sourceacademy.org/courses/#{course_id}/grading/#{submission_id}"
-    end
+  # TODO update this to use frontend url
+  defp build_submission_url(course_id, submission_id) do
+    "https://sourceacademy.org/courses/#{course_id}/grading/#{submission_id}"
+  end
 end

--- a/lib/cadet/email.ex
+++ b/lib/cadet/email.ex
@@ -27,6 +27,7 @@ defmodule Cadet.Email do
       |> assign(:avenger_name, avenger.name)
       |> assign(:student_name, student.name)
       |> assign(:assessment_title, submission.assessment.title)
+      |> assign(:submission_url, submission.submission_url)
       |> subject("New submission for #{submission.assessment.title}")
       |> render("#{template_file_name}.html")
     end

--- a/lib/cadet/email.ex
+++ b/lib/cadet/email.ex
@@ -9,6 +9,17 @@ defmodule Cadet.Email do
     if is_nil(avenger.email) do
       nil
     else
+      ungraded_submissions =
+        Enum.map(ungraded_submissions, fn submission ->
+          Map.put(
+            submission,
+            :submission_url,
+            build_submission_url(
+              submission[:student_course_id],
+              submission[:submission_id]
+            )
+          )
+        end)
       base_email()
       |> to(avenger.email)
       |> assign(:avenger_name, avenger.name)
@@ -22,12 +33,18 @@ defmodule Cadet.Email do
     if is_nil(avenger.email) do
       nil
     else
+      submission =
+        Map.put(
+          submission,
+          :submission_url,
+          build_submission_url(submission.assessment.course_id, submission.id)
+        )
+
       base_email()
       |> to(avenger.email)
       |> assign(:avenger_name, avenger.name)
       |> assign(:student_name, student.name)
-      |> assign(:assessment_title, submission.assessment.title)
-      |> assign(:submission_url, submission.submission_url)
+      |> assign(:submission, submission)
       |> subject("New submission for #{submission.assessment.title}")
       |> render("#{template_file_name}.html")
     end
@@ -38,4 +55,9 @@ defmodule Cadet.Email do
     |> from("noreply@sourceacademy.org")
     |> put_html_layout({CadetWeb.LayoutView, "email.html"})
   end
+
+    # TODO update this to use frontend url
+    defp build_submission_url(course_id, submission_id) do
+      "https://sourceacademy.org/courses/#{course_id}/grading/#{submission_id}"
+    end
 end

--- a/lib/cadet/workers/NotificationWorker.ex
+++ b/lib/cadet/workers/NotificationWorker.ex
@@ -69,10 +69,13 @@ defmodule Cadet.Workers.NotificationWorker do
       for course_id <- Cadet.Courses.get_all_course_ids() do
         if is_course_enabled(notification_type_id, course_id, nil) do
           avengers_crs = Cadet.Accounts.CourseRegistrations.get_staffs(course_id)
+
           for avenger_cr <- avengers_crs do
             avenger = Cadet.Accounts.get_user(avenger_cr.user_id)
+
             {:ok, ungraded_submissions} =
               Cadet.Assessments.get_ungraded_submission_for_email_notification(avenger_cr)
+
             if Enum.count(ungraded_submissions) < ungraded_threshold do
               IO.puts("[AVENGER_BACKLOG] below threshold!")
             else
@@ -84,6 +87,7 @@ defmodule Cadet.Workers.NotificationWorker do
                   avenger,
                   ungraded_submissions
                 )
+
               {status, email} = Mailer.deliver_now(email)
 
               if status == :ok do

--- a/lib/cadet/workers/NotificationWorker.ex
+++ b/lib/cadet/workers/NotificationWorker.ex
@@ -35,11 +35,6 @@ defmodule Cadet.Workers.NotificationWorker do
     end
   end
 
-  # TODO update this to use frontend url
-  defp build_submission_url(course_id, submission_id) do
-    "https://sourceacademy.org/courses/#{course_id}/grading/#{submission_id}"
-  end
-
   # Returns true if user preference matches the job's time option.
   # If user has made no preference, the default time option is used instead
   def is_user_time_option_matched(
@@ -85,18 +80,6 @@ defmodule Cadet.Workers.NotificationWorker do
               IO.puts("[AVENGER_BACKLOG] below threshold!")
             else
               IO.puts("[AVENGER_BACKLOG] SENDING_OUT")
-
-              ungraded_submissions =
-                Enum.map(ungraded_submissions, fn submission ->
-                  Map.put(
-                    submission,
-                    :submission_url,
-                    build_submission_url(
-                      submission[:student_course_id],
-                      submission[:submission_id]
-                    )
-                  )
-                end)
 
               email =
                 Email.avenger_backlog_email(
@@ -151,13 +134,6 @@ defmodule Cadet.Workers.NotificationWorker do
 
         true ->
           IO.puts("[ASSESSMENT_SUBMISSION] SENDING_OUT")
-
-          submission =
-            Map.put(
-              submission,
-              :submission_url,
-              build_submission_url(course_id, submission_id)
-            )
 
           email =
             Email.assessment_submission_email(

--- a/lib/cadet/workers/NotificationWorker.ex
+++ b/lib/cadet/workers/NotificationWorker.ex
@@ -35,6 +35,11 @@ defmodule Cadet.Workers.NotificationWorker do
     end
   end
 
+  # TODO update this to use frontend url
+  defp build_submission_url(course_id, submission_id) do
+    "https://sourceacademy.org/courses/#{course_id}/grading/#{submission_id}"
+  end
+
   # Returns true if user preference matches the job's time option.
   # If user has made no preference, the default time option is used instead
   def is_user_time_option_matched(
@@ -80,6 +85,18 @@ defmodule Cadet.Workers.NotificationWorker do
               IO.puts("[AVENGER_BACKLOG] below threshold!")
             else
               IO.puts("[AVENGER_BACKLOG] SENDING_OUT")
+
+              ungraded_submissions =
+                Enum.map(ungraded_submissions, fn submission ->
+                  Map.put(
+                    submission,
+                    :submission_url,
+                    build_submission_url(
+                      submission[:student_course_id],
+                      submission[:submission_id]
+                    )
+                  )
+                end)
 
               email =
                 Email.avenger_backlog_email(
@@ -134,6 +151,13 @@ defmodule Cadet.Workers.NotificationWorker do
 
         true ->
           IO.puts("[ASSESSMENT_SUBMISSION] SENDING_OUT")
+
+          submission =
+            Map.put(
+              submission,
+              :submission_url,
+              build_submission_url(course_id, submission_id)
+            )
 
           email =
             Email.assessment_submission_email(

--- a/lib/cadet_web/templates/email/assessment_submission.html.eex
+++ b/lib/cadet_web/templates/email/assessment_submission.html.eex
@@ -1,5 +1,5 @@
 <p> Dear <%= @avenger_name %>,</p>
 
-<p> There is a new submission by <%= @student_name %> for <a href="/"><%= @assessment_title %></a>. Please Review and grade the <a href="/">submission </a></p>
+<p> There is a new submission by <%= @student_name %> for <a href="<%= @submission_url %>"><%= @assessment_title %></a>. Please Review and grade the submission.</p>
 
 <a href="/">Unsubscribe</a> from this email topic.

--- a/lib/cadet_web/templates/email/assessment_submission.html.eex
+++ b/lib/cadet_web/templates/email/assessment_submission.html.eex
@@ -1,5 +1,5 @@
 <p> Dear <%= @avenger_name %>,</p>
 
-<p> There is a new submission by <%= @student_name %> for <a href="<%= @submission_url %>"><%= @assessment_title %></a>. Please Review and grade the submission.</p>
+<p> There is a new submission by <%= @student_name %> for <a href="<%= @submission.submission_url %>"><%= @submission.assessment.title %></a>. Please Review and grade the submission.</p>
 
 <a href="/">Unsubscribe</a> from this email topic.

--- a/lib/cadet_web/templates/email/avenger_backlog.html.eex
+++ b/lib/cadet_web/templates/email/avenger_backlog.html.eex
@@ -3,7 +3,7 @@
 You have ungraded submissions. Please review and grade the following submissions as soon as possible.
 
 <%= for s <- @submissions do %>
-    <p> <a href="/"><%= s["assessment"]["title"] %></a> by <%= s["student"]["name"]%> </p>
+    <p> <a href="/"><%= s[:assessment_title] %></a> by <%= s[:student_name] %> </p>
 <% end %>
 
 <a href="/">Unsubscribe</a> from this email topic.

--- a/lib/cadet_web/templates/email/avenger_backlog.html.eex
+++ b/lib/cadet_web/templates/email/avenger_backlog.html.eex
@@ -3,7 +3,7 @@
 You have ungraded submissions. Please review and grade the following submissions as soon as possible.
 
 <%= for s <- @submissions do %>
-    <p> <a href="/"><%= s[:assessment_title] %></a> by <%= s[:student_name] %> </p>
+    <p> <a href="<%= s[:submission_url] %>"><%= s[:assessment_title] %></a> by <%= s[:student_name] %> </p>
 <% end %>
 
 <a href="/">Unsubscribe</a> from this email topic.

--- a/test/cadet/email_test.exs
+++ b/test/cadet/email_test.exs
@@ -24,11 +24,8 @@ defmodule Cadet.EmailTest do
     avenger_user = insert(:user, %{email: "test@gmail.com"})
     avenger = insert(:course_registration, %{user: avenger_user, role: :staff})
 
-    {:ok, %{data: %{submissions: ungraded_submissions}}} =
-      Cadet.Assessments.submissions_by_grader_for_index(avenger, %{
-        "group" => "true",
-        "ungradedOnly" => "true"
-      })
+    {:ok, ungraded_submissions} =
+      Cadet.Assessments.get_ungraded_submission_for_email_notification(avenger)
 
     email = Email.avenger_backlog_email("avenger_backlog", avenger_user, ungraded_submissions)
 

--- a/test/cadet/jobs/notification_worker/notification_worker_test.exs
+++ b/test/cadet/jobs/notification_worker/notification_worker_test.exs
@@ -18,9 +18,9 @@ defmodule Cadet.NotificationWorker.NotificationWorkerTest do
     submission = List.first(List.first(data.mcq_answers)).submission
 
     # setup for avenger backlog
-    {:ok,  ungraded_submissions} =
+    {:ok, ungraded_submissions} =
       Cadet.Assessments.get_ungraded_submission_for_email_notification(avenger_cr)
-      IO.inspect(ungraded_submissions)
+
     Repo.update_all(NotificationType, set: [is_enabled: true])
     Repo.update_all(NotificationConfig, set: [is_enabled: true])
 

--- a/test/cadet/jobs/notification_worker/notification_worker_test.exs
+++ b/test/cadet/jobs/notification_worker/notification_worker_test.exs
@@ -18,12 +18,9 @@ defmodule Cadet.NotificationWorker.NotificationWorkerTest do
     submission = List.first(List.first(data.mcq_answers)).submission
 
     # setup for avenger backlog
-    {:ok, %{data: %{submissions: ungraded_submissions}}} =
-      Cadet.Assessments.submissions_by_grader_for_index(avenger_cr, %{
-        "group" => "true",
-        "notFullyGraded" => "true"
-      })
-
+    {:ok,  ungraded_submissions} =
+      Cadet.Assessments.get_ungraded_submission_for_email_notification(avenger_cr)
+      IO.inspect(ungraded_submissions)
     Repo.update_all(NotificationType, set: [is_enabled: true])
     Repo.update_all(NotificationConfig, set: [is_enabled: true])
 
@@ -41,6 +38,7 @@ defmodule Cadet.NotificationWorker.NotificationWorkerTest do
     perform_job(NotificationWorker, %{"notification_type" => "avenger_backlog"})
 
     avenger_email = avenger_user.email
+
     assert_delivered_email_matches(%{to: [{_, ^avenger_email}]})
   end
 

--- a/test/support/seeds.ex
+++ b/test/support/seeds.ex
@@ -180,7 +180,9 @@ defmodule Cadet.Test.Seeds do
     submissions =
       students
       |> Enum.take(2)
-      |> Enum.map(&insert(:submission, %{assessment: assessment, student: &1, status: :submitted}))
+      |> Enum.map(
+        &insert(:submission, %{assessment: assessment, student: &1, status: :submitted})
+      )
 
     # Programming Answers
     programming_answers =

--- a/test/support/seeds.ex
+++ b/test/support/seeds.ex
@@ -180,7 +180,7 @@ defmodule Cadet.Test.Seeds do
     submissions =
       students
       |> Enum.take(2)
-      |> Enum.map(&insert(:submission, %{assessment: assessment, student: &1}))
+      |> Enum.map(&insert(:submission, %{assessment: assessment, student: &1, status: :submitted}))
 
     # Programming Answers
     programming_answers =


### PR DESCRIPTION
- Implement dedicated function for getting ungraded submissions. It fetches only the bare minimum (assessment_title, student_name, submission_id and course_id)
- Refactor avenger backlog email template to use new function
- Refactor cron job to use new function
- Include status: submitted in test seed submissions
- Refactor tests to use the dedicated function

Closes #1040

Closes #1032 
Closes #939