### PR TITLE
Add IsContestRelated to AssessmentOverview

### DIFF
--- a/lib/cadet/courses/assessment_config.ex
+++ b/lib/cadet/courses/assessment_config.ex
@@ -12,7 +12,7 @@ defmodule Cadet.Courses.AssessmentConfig do
     field(:type, :string)
     field(:show_grading_summary, :boolean, default: true)
     field(:is_manually_graded, :boolean, default: true)
-    field(:has_token_counter, :boolean, default: false)
+    field(:is_contest_related, :boolean, default: false)
     # used by frontend to determine display styles
     field(:early_submission_xp, :integer, default: 0)
     field(:hours_before_early_xp_decay, :integer, default: 0)
@@ -24,7 +24,7 @@ defmodule Cadet.Courses.AssessmentConfig do
 
   @required_fields ~w(course_id)a
   @optional_fields ~w(order type early_submission_xp
-    hours_before_early_xp_decay show_grading_summary is_manually_graded has_token_counter)a
+    hours_before_early_xp_decay show_grading_summary is_manually_graded is_contest_related)a
 
   def changeset(assessment_config, params) do
     assessment_config

--- a/lib/cadet_web/admin_views/admin_assessments_view.ex
+++ b/lib/cadet_web/admin_views/admin_assessments_view.ex
@@ -27,7 +27,8 @@ defmodule CadetWeb.AdminAssessmentsView do
       private: &password_protected?(&1.password),
       isPublished: :is_published,
       questionCount: :question_count,
-      gradedCount: &(&1.graded_count || 0)
+      gradedCount: &(&1.graded_count || 0),
+      isContestRelated: & &1.config.is_contest_related
     })
   end
 

--- a/lib/cadet_web/admin_views/admin_courses_view.ex
+++ b/lib/cadet_web/admin_views/admin_courses_view.ex
@@ -12,7 +12,7 @@ defmodule CadetWeb.AdminCoursesView do
       displayInDashboard: :show_grading_summary,
       isManuallyGraded: :is_manually_graded,
       earlySubmissionXp: :early_submission_xp,
-      hasTokenCounter: :has_token_counter,
+      isContestRelated: :is_contest_related,
       hoursBeforeEarlyXpDecay: :hours_before_early_xp_decay
     })
   end

--- a/lib/cadet_web/views/assessments_view.ex
+++ b/lib/cadet_web/views/assessments_view.ex
@@ -28,7 +28,8 @@ defmodule CadetWeb.AssessmentsView do
       private: &password_protected?(&1.password),
       isPublished: :is_published,
       questionCount: :question_count,
-      gradedCount: &(&1.graded_count || 0)
+      gradedCount: &(&1.graded_count || 0),
+      isContestRelated: & &1.config.is_contest_related
     })
   end
 

--- a/lib/cadet_web/views/user_view.ex
+++ b/lib/cadet_web/views/user_view.ex
@@ -125,7 +125,7 @@ defmodule CadetWeb.UserView do
             type: :type,
             displayInDashboard: :show_grading_summary,
             isManuallyGraded: :is_manually_graded,
-            hasTokenCounter: :has_token_counter,
+            isContestRelated: :is_contest_related,
             earlySubmissionXp: :early_submission_xp,
             hoursBeforeEarlyXpDecay: :hours_before_early_xp_decay
           })

--- a/priv/repo/migrations/20240306140225_rename_has_token_counter.exs
+++ b/priv/repo/migrations/20240306140225_rename_has_token_counter.exs
@@ -1,0 +1,7 @@
+defmodule Cadet.Repo.Migrations.RenameHasTokenCounter do
+  use Ecto.Migration
+
+  def change do
+    rename(table(:assessment_configs), :has_token_counter, to: :is_contest_related)
+  end
+end

--- a/test/cadet_web/admin_controllers/admin_assessments_controller_test.exs
+++ b/test/cadet_web/admin_controllers/admin_assessments_controller_test.exs
@@ -89,7 +89,8 @@ defmodule CadetWeb.AdminAssessmentsControllerTest do
             "isPublished" => &1.is_published,
             "gradedCount" => 0,
             "questionCount" => 9,
-            "xp" => (800 + 500 + 100) * 3
+            "xp" => (800 + 500 + 100) * 3,
+            "isContestRelated" => &1.config.is_contest_related
           }
         )
 
@@ -135,7 +136,8 @@ defmodule CadetWeb.AdminAssessmentsControllerTest do
             "isPublished" => &1.is_published,
             "gradedCount" => 0,
             "questionCount" => 9,
-            "xp" => 0
+            "xp" => 0,
+            "isContestRelated" => &1.config.is_contest_related
           }
         )
 

--- a/test/cadet_web/admin_controllers/admin_courses_controller_test.exs
+++ b/test/cadet_web/admin_controllers/admin_courses_controller_test.exs
@@ -158,7 +158,7 @@ defmodule CadetWeb.AdminCoursesControllerTest do
           order: 2,
           type: "Mission2",
           course: course,
-          has_token_counter: true
+          is_contest_related: true
         })
 
       resp =
@@ -174,7 +174,7 @@ defmodule CadetWeb.AdminCoursesControllerTest do
           "isManuallyGraded" => true,
           "type" => "Mission1",
           "assessmentConfigId" => config1.id,
-          "hasTokenCounter" => false
+          "isContestRelated" => false
         },
         %{
           "earlySubmissionXp" => 200,
@@ -183,7 +183,7 @@ defmodule CadetWeb.AdminCoursesControllerTest do
           "isManuallyGraded" => false,
           "type" => "Mission2",
           "assessmentConfigId" => config2.id,
-          "hasTokenCounter" => true
+          "isContestRelated" => true
         },
         %{
           "earlySubmissionXp" => 200,
@@ -192,7 +192,7 @@ defmodule CadetWeb.AdminCoursesControllerTest do
           "isManuallyGraded" => true,
           "type" => "Mission3",
           "assessmentConfigId" => config3.id,
-          "hasTokenCounter" => false
+          "isContestRelated" => false
         }
       ]
 

--- a/test/cadet_web/controllers/assessments_controller_test.exs
+++ b/test/cadet_web/controllers/assessments_controller_test.exs
@@ -78,7 +78,8 @@ defmodule CadetWeb.AssessmentsControllerTest do
               "private" => false,
               "isPublished" => &1.is_published,
               "gradedCount" => 0,
-              "questionCount" => 9
+              "questionCount" => 9,
+              "isContestRelated" => &1.config.is_contest_related
             }
           )
 
@@ -161,7 +162,8 @@ defmodule CadetWeb.AssessmentsControllerTest do
             "private" => false,
             "isPublished" => &1.is_published,
             "gradedCount" => 0,
-            "questionCount" => 9
+            "questionCount" => 9,
+            "isContestRelated" => &1.config.is_contest_related
           }
         )
 
@@ -271,6 +273,7 @@ defmodule CadetWeb.AssessmentsControllerTest do
               "private" => false,
               "gradedCount" => 0,
               "questionCount" => 9,
+              "isContestRelated" => &1.config.is_contest_related,
               "isPublished" =>
                 if &1.config.type == hd(configs).type do
                   false

--- a/test/cadet_web/controllers/user_controller_test.exs
+++ b/test/cadet_web/controllers/user_controller_test.exs
@@ -123,7 +123,7 @@ defmodule CadetWeb.UserControllerTest do
             "assessmentConfigId" => config1.id,
             "earlySubmissionXp" => 200,
             "hoursBeforeEarlyXpDecay" => 48,
-            "hasTokenCounter" => false
+            "isContestRelated" => false
           },
           %{
             "type" => "test type 2",
@@ -132,7 +132,7 @@ defmodule CadetWeb.UserControllerTest do
             "assessmentConfigId" => config2.id,
             "earlySubmissionXp" => 200,
             "hoursBeforeEarlyXpDecay" => 48,
-            "hasTokenCounter" => false
+            "isContestRelated" => false
           },
           %{
             "type" => "test type 3",
@@ -141,7 +141,7 @@ defmodule CadetWeb.UserControllerTest do
             "assessmentConfigId" => config3.id,
             "earlySubmissionXp" => 200,
             "hoursBeforeEarlyXpDecay" => 48,
-            "hasTokenCounter" => false
+            "isContestRelated" => false
           }
         ]
       }


### PR DESCRIPTION
This PR supports the new tab for contests related assessments in ground control. Changed 'Has Token Counter' to 'Is Contest Related' for consistency and implement logic. Added 'Has Token Counter' to assessmentOverview in order to identify if the assessment is contest at FrontEnd. 

**Changes to be made:**

- [X] Added migration to rename has_token_counter to is_contest_related
- [X] Changed has_token_counter to is_contest_related
- [X] Added is_contest_related to Overview
- [X] Modified test cases to match