### PR TITLE
Add sorting for grading

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1569,10 +1569,6 @@ defmodule Cadet.Assessments do
 
     {:ok, %{count: count, data: generate_grading_summary_view_model(submissions, course_id)}}
   end
-  defp print_sql(queryable) do
-    IO.inspect(Ecto.Adapters.SQL.to_sql(:all, Repo, queryable))
-    queryable
-  end
   # Given a query from submissions_by_grader_for_index,
   # sorts it by the relevant field and direction
   # sort_by is a string of either "", "assessmentName", "assessmentType", "studentName",

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1528,7 +1528,6 @@ defmodule Cadet.Assessments do
         where: s.assessment_id in subquery(build_assessment_config_filter(params)),
         where: ^build_submission_filter(params),
         where: ^build_course_registration_filter(params, grader),
-        order_by: [desc: s.inserted_at],
         limit: ^elem(Integer.parse(Map.get(params, "pageSize", "10")), 0),
         offset: ^elem(Integer.parse(Map.get(params, "offset", "0")), 0),
         select: %{
@@ -1547,6 +1546,7 @@ defmodule Cadet.Assessments do
         }
       )
     query = sort_submission(query, Map.get(params, "sortBy", ""), Map.get(params, "sortDirection", ""))
+    query = from [s, ans, asst, user] in query, order_by: [desc: s.inserted_at]
     submissions = Repo.all(query)
 
     count_query =
@@ -1569,7 +1569,10 @@ defmodule Cadet.Assessments do
 
     {:ok, %{count: count, data: generate_grading_summary_view_model(submissions, course_id)}}
   end
-
+  defp print_sql(queryable) do
+    IO.inspect(Ecto.Adapters.SQL.to_sql(:all, Repo, queryable))
+    queryable
+  end
   # Given a query from submissions_by_grader_for_index,
   # sorts it by the relevant field and direction
   # sort_by is a string of either "", "assessmentName", "assessmentType", "studentName",

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1520,7 +1520,7 @@ defmodule Cadet.Assessments do
         left_join: asst in subquery(question_answers_query),
         on: asst.assessment_id == s.assessment_id,
         as: :asst,
-        inner_join: user in User,
+        left_join: user in User,
         on: user.id == s.student_id,
         as: :user,
         where: ^build_user_filter(params),

--- a/test/cadet/assessments/assessments_test.exs
+++ b/test/cadet/assessments/assessments_test.exs
@@ -2516,6 +2516,73 @@ defmodule Cadet.AssessmentsTest do
         assert Enum.find(assessments_from_res, fn a -> a.id == s.assessment_id end) != nil
       end)
     end
+
+    test "sorting by assessment title ascending", %{
+      course_regs: %{avenger1_cr: avenger},
+      assessments: assessments,
+      total_submissions: total_submissions
+    } do
+
+      {_, res} =
+        Assessments.submissions_by_grader_for_index(avenger, %{
+          "pageSize" => total_submissions,
+          "sortBy" => "assessmentName",
+          "sortDirection" => "sort-asc"
+        })
+
+      submissions_from_res = res[:data][:submissions]
+      assessments_from_res = res[:data][:assessments]
+
+      submissions_by_title = Enum.map(
+        submissions_from_res,
+        fn s ->
+          Enum.find(assessments_from_res, fn a ->
+            s.assessment_id == a.id
+          end)
+        end
+      )
+
+      Enum.reduce(submissions_by_title,
+        fn x, y ->
+          assert x.title >= y.title
+          y
+        end
+      )
+    end
+
+    test "sorting by assessment title descending", %{
+      course_regs: %{avenger1_cr: avenger},
+      assessments: assessments,
+      total_submissions: total_submissions
+    } do
+      assessment = assessments["mission"][:assessment]
+
+      {_, res} =
+        Assessments.submissions_by_grader_for_index(avenger, %{
+          "pageSize" => total_submissions,
+          "sortBy" => "assessmentName",
+          "sortDirection" => "sort-desc"
+        })
+
+        submissions_from_res = res[:data][:submissions]
+        assessments_from_res = res[:data][:assessments]
+
+        submissions_by_title = Enum.map(
+          submissions_from_res,
+          fn s ->
+            Enum.find(assessments_from_res, fn a ->
+              s.assessment_id == a.id
+            end)
+          end
+        )
+
+        Enum.reduce(submissions_by_title,
+          fn x, y ->
+            assert x.title <= y.title
+            y
+          end
+        )
+    end
   end
 
   defp get_answer_relative_scores(answers) do


### PR DESCRIPTION
### Description

**To be merged with Frontend #2893**

Blocked by #965 

For implementation decisions, see Frontend PR.

### Changes
- Changed `submissions_by_grader_for_index` pipeline by adding user table, assessment.title and assessment.config_id 
- Added `sort_submission` to sort the query in the pipeline

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
