### PR TITLE
Create release for `deploy-stg` branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,16 +29,16 @@ jobs:
       OTP_VERSION: 25.3.2
     steps:
       - uses: rlespinasse/github-slug-action@v3.x
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
           restore-keys: |
             ${{ runner.os }}-mix-
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             _build

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,7 @@ on:
       - stable
       - master
       - deploy
+      - deploy-stg
     paths:
       - "config/**"
       - "lib/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,16 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
           restore-keys: |
             ${{ runner.os }}-mix-
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             _build


### PR DESCRIPTION
Updates the CD workflow to also build releases for the `deploy-stg` branch.

By separating the prod `deploy` and stg `deploy-stg` branches, this allows a functioning prod release to still be kept in the event that the stg binary is broken.

Also updates workflow dependencies.