### PR TITLE
fix sorting for grading

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1943,12 +1943,12 @@ defmodule Cadet.Assessments do
         left_join: asst in subquery(question_answers_query),
         on: asst.assessment_id == s.assessment_id,
         as: :asst,
-        left_join: user in User,
-        on: user.id == s.student_id,
-        as: :user,
         left_join: cr in CourseRegistration,
-        on: user.id == cr.user_id,
+        on: s.student_id == cr.id,
         as: :cr,
+        left_join: user in User,
+        on: user.id == cr.user_id,
+        as: :user,
         left_join: group in Group,
         on: cr.group_id == group.id,
         as: :group,
@@ -1982,7 +1982,7 @@ defmodule Cadet.Assessments do
     query =
       sort_submission(query, Map.get(params, "sortBy", ""), Map.get(params, "sortDirection", ""))
 
-    query = from([s, ans, asst, user, cr, group] in query, order_by: [desc: s.inserted_at])
+    query = from([s, ans, asst, cr, user, group] in query, order_by: [desc: s.inserted_at])
     submissions = Repo.all(query)
 
     count_query =
@@ -2027,30 +2027,30 @@ defmodule Cadet.Assessments do
   defp sort_submission_asc(query, sort_by) do
     cond do
       sort_by == "assessmentName" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: fragment("upper(?)", asst.title)
         )
 
       sort_by == "assessmentType" ->
-        from([s, ans, asst, user, cr, group, config] in query, order_by: asst.config_id)
+        from([s, ans, asst, cr, user, group, config] in query, order_by: asst.config_id)
 
       sort_by == "studentName" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: fragment("upper(?)", user.name)
         )
 
       sort_by == "studentUsername" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: fragment("upper(?)", user.username)
         )
 
       sort_by == "groupName" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: fragment("upper(?)", group.name)
         )
 
       sort_by == "progressStatus" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: [
             asc: config.is_manually_graded,
             asc: s.status,
@@ -2060,7 +2060,7 @@ defmodule Cadet.Assessments do
         )
 
       sort_by == "xp" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: ans.xp + ans.xp_adjustment
         )
 
@@ -2072,30 +2072,30 @@ defmodule Cadet.Assessments do
   defp sort_submission_desc(query, sort_by) do
     cond do
       sort_by == "assessmentName" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: [desc: fragment("upper(?)", asst.title)]
         )
 
       sort_by == "assessmentType" ->
-        from([s, ans, asst, user, cr, group, config] in query, order_by: [desc: asst.config_id])
+        from([s, ans, asst, cr, user, group, config] in query, order_by: [desc: asst.config_id])
 
       sort_by == "studentName" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: [desc: fragment("upper(?)", user.name)]
         )
 
       sort_by == "studentUsername" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: [desc: fragment("upper(?)", user.username)]
         )
 
       sort_by == "groupName" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: [desc: fragment("upper(?)", group.name)]
         )
 
       sort_by == "progressStatus" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: [
             desc: config.is_manually_graded,
             desc: s.status,
@@ -2105,7 +2105,7 @@ defmodule Cadet.Assessments do
         )
 
       sort_by == "xp" ->
-        from([s, ans, asst, user, cr, group, config] in query,
+        from([s, ans, asst, cr, user, group, config] in query,
           order_by: [desc: ans.xp + ans.xp_adjustment]
         )
 

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1982,7 +1982,9 @@ defmodule Cadet.Assessments do
     query =
       sort_submission(query, Map.get(params, "sortBy", ""), Map.get(params, "sortDirection", ""))
 
-    query = from([s, ans, asst, cr, user, group] in query, order_by: [desc: s.inserted_at, asc: s.id])
+    query =
+      from([s, ans, asst, cr, user, group] in query, order_by: [desc: s.inserted_at, asc: s.id])
+
     submissions = Repo.all(query)
 
     count_query =

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1982,7 +1982,7 @@ defmodule Cadet.Assessments do
     query =
       sort_submission(query, Map.get(params, "sortBy", ""), Map.get(params, "sortDirection", ""))
 
-    query = from([s, ans, asst, cr, user, group] in query, order_by: [desc: s.inserted_at])
+    query = from([s, ans, asst, cr, user, group] in query, order_by: [desc: s.inserted_at, asc: s.id])
     submissions = Repo.all(query)
 
     count_query =


### PR DESCRIPTION
### Description

Currently there is a bug in source academy grading table where users are unable to sort by username and group

### Changes
- There was a bug where a left join condition was done on `user.id == submissions.student_id` and `user.id == courseRegistration.user_id`
- However, in the schema the conditions are `courseRegistration.id == submissions.student_id` and `courseRegistration.user_id == user.id`
- An additional bug was found during testing where the same row kept appearing every page. This happens when `submission.inserted_at` is the same which prevents LIMIT from working as the sort may be inconsistent.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
