### PR TITLE
fix: Fix notifications of type "submitted" not being read

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1139,6 +1139,13 @@ defmodule Cadet.Assessments do
           )
       end
 
+      # Remove grading notifications for submissions
+      Notification
+      |> where(submission_id: ^submission_id, type: :submitted)
+      |> select([n], n.id)
+      |> Repo.all()
+      |> Notifications.acknowledge(cr)
+
       {:ok, nil}
     else
       {:submission_found?, false} ->

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1250,6 +1250,12 @@ defmodule Cadet.Assessments do
           :published_grading
         )
 
+        Notification
+        |> where([submission_id: ^submission.id, type: :submitted])
+        |> select([n], n.id)
+        |> Repo.all()
+        |> Notifications.acknowledge(cr)
+
         {:ok, nil}
 
       {:submission_found?, false} ->

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1251,7 +1251,7 @@ defmodule Cadet.Assessments do
         )
 
         Notification
-        |> where([submission_id: ^submission.id, type: :submitted])
+        |> where(submission_id: ^submission.id, type: :submitted)
         |> select([n], n.id)
         |> Repo.all()
         |> Notifications.acknowledge(cr)


### PR DESCRIPTION
Currently the notifications are not marked as read for type: submitted. When the grading is published, be it manually or automatically, the notification will be marked as read. The grading notification should also be marked as read when the submission is unsubmitted.

I feel that notifications should signify that there are things to be done on the grading page. This solution resolves this bug of there being "things to do" even though there aren't any.
<img width="1468" alt="Screenshot 2024-08-26 at 10 31 20 PM" src="https://github.com/user-attachments/assets/56c51088-eab7-47b3-82f1-c5f27d7fe784">
