### PR TITLE
fix: Fix unintended auto-publishing of autograder

### DIFF
--- a/lib/cadet/jobs/autograder/grading_job.ex
+++ b/lib/cadet/jobs/autograder/grading_job.ex
@@ -265,8 +265,10 @@ defmodule Cadet.Autograder.GradingJob do
     assessment = Repo.get(Assessment, submission.assessment_id)
     assessment_config = Repo.get_by(AssessmentConfig, id: assessment.config_id)
     is_grading_auto_published = assessment_config.is_grading_auto_published
+    is_manually_graded = assessment_config.is_manually_graded
 
-    if Assessments.is_fully_autograded?(submission_id) and is_grading_auto_published do
+    if Assessments.is_fully_autograded?(submission_id) and is_grading_auto_published and
+         not is_manually_graded do
       Assessments.publish_grading(submission_id)
     end
   end

--- a/test/cadet/jobs/autograder/grading_job_test.exs
+++ b/test/cadet/jobs/autograder/grading_job_test.exs
@@ -24,7 +24,7 @@ defmodule Cadet.Autograder.GradingJobTest do
   describe "#force_grade_individual_submission, all programming questions" do
     setup do
       course = insert(:course)
-      assessment_config = insert(:assessment_config, %{course: course})
+      assessment_config = insert(:assessment_config, %{course: course, is_grading_auto_published: true, is_manually_graded: false})
 
       assessments =
         insert_list(3, :assessment, %{
@@ -416,7 +416,7 @@ defmodule Cadet.Autograder.GradingJobTest do
       course = insert(:course)
 
       assessment_config =
-        insert(:assessment_config, %{course: course, is_grading_auto_published: true})
+        insert(:assessment_config, %{course: course, is_grading_auto_published: true, is_manually_graded: false})
 
       assessments =
         insert_list(3, :assessment, %{
@@ -648,7 +648,7 @@ defmodule Cadet.Autograder.GradingJobTest do
       course = insert(:course)
 
       assessment_config =
-        insert(:assessment_config, %{course: course, is_grading_auto_published: true})
+        insert(:assessment_config, %{course: course, is_grading_auto_published: true, is_manually_graded: false})
 
       assessments =
         insert_list(3, :assessment, %{

--- a/test/cadet/jobs/autograder/grading_job_test.exs
+++ b/test/cadet/jobs/autograder/grading_job_test.exs
@@ -24,7 +24,13 @@ defmodule Cadet.Autograder.GradingJobTest do
   describe "#force_grade_individual_submission, all programming questions" do
     setup do
       course = insert(:course)
-      assessment_config = insert(:assessment_config, %{course: course, is_grading_auto_published: true, is_manually_graded: false})
+
+      assessment_config =
+        insert(:assessment_config, %{
+          course: course,
+          is_grading_auto_published: true,
+          is_manually_graded: false
+        })
 
       assessments =
         insert_list(3, :assessment, %{
@@ -416,7 +422,11 @@ defmodule Cadet.Autograder.GradingJobTest do
       course = insert(:course)
 
       assessment_config =
-        insert(:assessment_config, %{course: course, is_grading_auto_published: true, is_manually_graded: false})
+        insert(:assessment_config, %{
+          course: course,
+          is_grading_auto_published: true,
+          is_manually_graded: false
+        })
 
       assessments =
         insert_list(3, :assessment, %{
@@ -648,7 +658,11 @@ defmodule Cadet.Autograder.GradingJobTest do
       course = insert(:course)
 
       assessment_config =
-        insert(:assessment_config, %{course: course, is_grading_auto_published: true, is_manually_graded: false})
+        insert(:assessment_config, %{
+          course: course,
+          is_grading_auto_published: true,
+          is_manually_graded: false
+        })
 
       assessments =
         insert_list(3, :assessment, %{


### PR DESCRIPTION
Currently the autograder autopublishes when all answers are successfully autograded and if `is_grading_auto_published` is true.

Autograder should only be auto publishing when there is no need for manual intervention as well. Therefore, we should also be checking if `is_manually_graded` is false.

Closes: https://github.com/source-academy/backend/issues/1164