### PR TITLE
feat: Add check to notification creation

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1021,7 +1021,12 @@ defmodule Cadet.Assessments do
     with {:status, :attempted} <- {:status, submission.status},
          {:ok, updated_submission} <- update_submission_status(submission) do
       # Couple with update_submission_status and update_xp_bonus to ensure notification is sent
-      Notifications.write_notification_when_student_submits(submission)
+      submission = Repo.preload(submission, assessment: [:config])
+
+      if submission.assessment.config.is_manually_graded do
+        Notifications.write_notification_when_student_submits(submission)
+      end
+
       # Send email notification to avenger
       %{notification_type: "assessment_submission", submission_id: updated_submission.id}
       |> Cadet.Workers.NotificationWorker.new()


### PR DESCRIPTION
This PR adds a check to finalise submission. It will only create a notification if the assessment requires manual grading. This would mean that the staff has a TODO and thus a notification should be created.

In the context of CS1101S: Paths are autograded and require no manual grading. Without this check, staff will receive a notification under the grading tab but there is no action required. There is also no way to resolve the notification easily as the submission is autograded and autopublished. 

Closes: https://github.com/source-academy/backend/issues/1166