### PR TITLE
Fix issues with bonus xp

### DIFF
--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1455,11 +1455,10 @@ defmodule Cadet.Assessments do
         Answer
         |> where(submission_id: ^submission_id)
         |> order_by(:question_id)
-        |> group_by([a], a.id)
         |> select([a], %{
           # grouping by submission, so s.xp_bonus will be the same, but we need an
           # aggregate function
-          total_xp: sum(a.xp) + sum(a.xp_adjustment)
+          total_xp: a.xp + a.xp_adjustment
         })
 
       total =
@@ -1470,8 +1469,6 @@ defmodule Cadet.Assessments do
         })
         |> Repo.one()
 
-      xp = decimal_to_integer(total.total_xp)
-
       cur_time =
         if submission.submitted_at == nil do
           Timex.now()
@@ -1480,7 +1477,7 @@ defmodule Cadet.Assessments do
         end
 
       xp_bonus =
-        if xp <= 0 do
+        if total.total_xp <= 0 do
           0
         else
           if Timex.before?(cur_time, Timex.shift(assessment.open_at, hours: early_hours)) do

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1034,7 +1034,7 @@ defmodule Cadet.Assessments do
 
       # Begin autograding job
       GradingJob.force_grade_individual_submission(updated_submission)
-      update_xp_bonus(submission)
+      update_xp_bonus(updated_submission)
 
       {:ok, nil}
     else

--- a/lib/cadet/assessments/assessments.ex
+++ b/lib/cadet/assessments/assessments.ex
@@ -1257,6 +1257,8 @@ defmodule Cadet.Assessments do
         |> Submission.changeset(%{is_grading_published: true})
         |> Repo.update()
 
+        update_xp_bonus(submission)
+
         Notifications.write_notification_when_published(
           submission.id,
           :published_grading


### PR DESCRIPTION
### Description

Resolves #1168, #1170.

Some issues with the code and fixes the bug where autograded assignments do not have bonus xp awarded. The bug is fixed by updating bonus xp when grading is published.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation