### PR TITLE
fix: Fix empty submisisons creation for team assessments

### DIFF
--- a/lib/cadet/assessments/submission.ex
+++ b/lib/cadet/assessments/submission.ex
@@ -45,6 +45,7 @@ defmodule Cadet.Assessments.Submission do
     |> foreign_key_constraint(:student_id)
     |> foreign_key_constraint(:assessment_id)
     |> foreign_key_constraint(:unsubmitted_by_id)
+    |> unique_constraint(:unique_team_id, name: :submissions_team_id_assessment_id_unique_index)
   end
 
   defp validate_xor_relationship(changeset) do

--- a/lib/cadet/assessments/submission.ex
+++ b/lib/cadet/assessments/submission.ex
@@ -43,9 +43,9 @@ defmodule Cadet.Assessments.Submission do
     |> validate_xor_relationship
     |> validate_required(@required_fields)
     |> foreign_key_constraint(:student_id)
+    |> foreign_key_constraint(:team_id)
     |> foreign_key_constraint(:assessment_id)
     |> foreign_key_constraint(:unsubmitted_by_id)
-    |> unique_constraint(:unique_team_id, name: :submissions_team_id_assessment_id_unique_index)
   end
 
   defp validate_xor_relationship(changeset) do

--- a/lib/cadet/jobs/autograder/grading_job.ex
+++ b/lib/cadet/jobs/autograder/grading_job.ex
@@ -135,18 +135,31 @@ defmodule Cadet.Autograder.GradingJob do
           team
         end
 
-      %Submission{}
-      |> Submission.changeset(%{
-        team_id: team.id,
-        assessment: assessment,
-        status: :submitted
-      })
-      |> Repo.insert!()
+      find_or_create_team_submission(team.id, assessment)
     else
       # Individual assessment
       %Submission{}
       |> Submission.changeset(%{
         student_id: student_id,
+        assessment: assessment,
+        status: :submitted
+      })
+      |> Repo.insert!()
+    end
+  end
+
+  defp find_or_create_team_submission(team_id, assessment) when is_ecto_id(team_id) do
+    submission =
+      Submission
+      |> where(team_id: ^team_id, assessment_id: ^assessment.id)
+      |> Repo.one()
+
+    if submission do
+      submission
+    else
+      %Submission{}
+      |> Submission.changeset(%{
+        team_id: team_id,
         assessment: assessment,
         status: :submitted
       })

--- a/lib/cadet/jobs/autograder/grading_job.ex
+++ b/lib/cadet/jobs/autograder/grading_job.ex
@@ -116,7 +116,7 @@ defmodule Cadet.Autograder.GradingJob do
         if team do
           team
         else
-                    # Student is not in any team
+          # Student is not in any team
           # Create new team just for the student
           team =
             %Team{}

--- a/lib/cadet/jobs/autograder/grading_job.ex
+++ b/lib/cadet/jobs/autograder/grading_job.ex
@@ -112,23 +112,28 @@ defmodule Cadet.Autograder.GradingJob do
         |> where([_, tm], tm.student_id == ^student_id)
         |> Repo.one()
 
-      if !team do
-        # Student is not in any team
-        # Create new team just for the student
-        team =
-          %Team{}
-          |> Team.changeset(%{
-            assessment_id: assessment.id
+      team =
+        if !team do
+          # Student is not in any team
+          # Create new team just for the student
+          team =
+            %Team{}
+            |> Team.changeset(%{
+              assessment_id: assessment.id
+            })
+            |> Repo.insert!()
+
+          %TeamMember{}
+          |> TeamMember.changeset(%{
+            team_id: team.id,
+            student_id: student_id
           })
           |> Repo.insert!()
 
-        %TeamMember{}
-        |> TeamMember.changeset(%{
-          team_id: team.id,
-          student_id: student_id
-        })
-        |> Repo.insert!()
-      end
+          team
+        else
+          team
+        end
 
       %Submission{}
       |> Submission.changeset(%{

--- a/lib/cadet/jobs/autograder/grading_job.ex
+++ b/lib/cadet/jobs/autograder/grading_job.ex
@@ -113,8 +113,10 @@ defmodule Cadet.Autograder.GradingJob do
         |> Repo.one()
 
       team =
-        if !team do
-          # Student is not in any team
+        if team do
+          team
+        else
+                    # Student is not in any team
           # Create new team just for the student
           team =
             %Team{}
@@ -130,8 +132,6 @@ defmodule Cadet.Autograder.GradingJob do
           })
           |> Repo.insert!()
 
-          team
-        else
           team
         end
 

--- a/priv/repo/migrations/20241014200600_create_teams_submission_constraint.exs
+++ b/priv/repo/migrations/20241014200600_create_teams_submission_constraint.exs
@@ -1,17 +1,8 @@
 defmodule Cadet.Repo.Migrations.CreateTeamsSubmissionConstraint do
   use Ecto.Migration
 
-  def up do
-    create(
-      unique_index(
-        :submissions,
-        [:team_id, :assessment_id],
-        name: :submissions_team_id_assessment_id_unique_index
-      )
-    )
-  end
-
-  def down do
-    drop(constraint(:submissions, :submissions_team_id_assessment_id_unique_index))
+  def change do
+    create(index(:submissions, :team_id))
+    create(unique_index(:submissions, [:assessment_id, :team_id]))
   end
 end

--- a/priv/repo/migrations/20241014200600_create_teams_submission_constraint.exs
+++ b/priv/repo/migrations/20241014200600_create_teams_submission_constraint.exs
@@ -1,0 +1,17 @@
+defmodule Cadet.Repo.Migrations.CreateTeamsSubmissionConstraint do
+  use Ecto.Migration
+
+  def up do
+    create(
+      unique_index(
+        :submissions,
+        [:team_id, :assessment_id],
+        name: :submissions_team_id_assessment_id_unique_index
+      )
+    )
+  end
+
+  def down do
+    drop(constraint(:submissions, :submissions_team_id_assessment_id_unique_index))
+  end
+end


### PR DESCRIPTION
- Add migration to include a unique index for (team_id, assessment_id) in submissions
- Fix logic for creation of empty submissions