### PR TITLE
Create flow for token exchange needed for VSC extension

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,7 +27,7 @@ config :cadet, Cadet.Jobs.Scheduler,
     # Collate contest entries that close in the previous day at 00:01
     {"1 0 * * *", {Cadet.Assessments, :update_final_contest_entries, []}},
     # Clean up expired exchange tokens at 00:01
-    {"1 0 * * *", {Cadet.CodeExchange, :delete_expired, []}}
+    {"1 0 * * *", {Cadet.TokenExchange, :delete_expired, []}}
   ]
 
 # Configures the endpoint

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,7 +25,9 @@ config :cadet, Cadet.Jobs.Scheduler,
     # Compute rolling leaderboard every 2 hours
     {"0 */2 * * *", {Cadet.Assessments, :update_rolling_contest_leaderboards, []}},
     # Collate contest entries that close in the previous day at 00:01
-    {"1 0 * * *", {Cadet.Assessments, :update_final_contest_entries, []}}
+    {"1 0 * * *", {Cadet.Assessments, :update_final_contest_entries, []}},
+    # Clean up expired exchange tokens at 00:01
+    {"1 0 * * *", {Cadet.CodeExchange, :delete_expired, []}}
   ]
 
 # Configures the endpoint

--- a/config/dev.secrets.exs.example
+++ b/config/dev.secrets.exs.example
@@ -36,6 +36,8 @@ config :cadet,
     #    %{
     #      assertion_extractor: Cadet.Auth.Providers.NusstuAssertionExtractor,
     #      client_redirect_url: "http://cadet.frontend:8000/login/callback"
+    #      vscode_redirect_url_prefix: "vscode://source-academy.source-academy/sso",
+    #      client_post_exchange_redirect_url: "http://cadet.frontend:8000/login/vscode_callback",
     #    }},
 
     "test" =>

--- a/lib/cadet/code_exchange.ex
+++ b/lib/cadet/code_exchange.ex
@@ -1,6 +1,6 @@
-defmodule Cadet.CodeExchange do
+defmodule Cadet.TokenExchange do
   @moduledoc """
-  The CodeExchange entity stores short-lived codes to be exchanged for long-lived auth tokens.
+  The TokenExchange entity stores short-lived codes to be exchanged for long-lived auth tokens.
   """
   use Cadet, :model
 
@@ -9,7 +9,7 @@ defmodule Cadet.CodeExchange do
   alias Cadet.Repo
   alias Cadet.Accounts.User
 
-  schema "code_exchange" do
+  schema "token_exchange" do
     field(:code, :string)
     field(:generated_at, :utc_datetime_usec)
     field(:expires_at, :utc_datetime_usec)

--- a/lib/cadet_web/controllers/auth_controller.ex
+++ b/lib/cadet_web/controllers/auth_controller.ex
@@ -8,7 +8,7 @@ defmodule CadetWeb.AuthController do
   alias Cadet.Accounts
   alias Cadet.Accounts.User
   alias Cadet.Auth.{Guardian, Provider}
-  alias Cadet.CodeExchange
+  alias Cadet.TokenExchange
 
   @doc """
   Receives a /login request with valid attributes.
@@ -95,7 +95,7 @@ defmodule CadetWeb.AuthController do
       "provider" => provider
     }
   ) do
-    case CodeExchange.get_by_code(code) do
+    case TokenExchange.get_by_code(code) do
       {:error, _message} ->
         conn
         |> put_status(:forbidden)
@@ -131,7 +131,7 @@ defmodule CadetWeb.AuthController do
     }) do
       {:ok, user} ->
         code = generate_code()
-        CodeExchange.insert(%{
+        TokenExchange.insert(%{
           code: code,
           generated_at: Timex.now(),
           expires_at: Timex.add(Timex.now(), Timex.Duration.from_seconds(code_ttl)),

--- a/lib/cadet_web/router.ex
+++ b/lib/cadet_web/router.ex
@@ -51,6 +51,8 @@ defmodule CadetWeb.Router do
     post("/auth/login", AuthController, :create)
     post("/auth/logout", AuthController, :logout)
     get("/auth/saml_redirect", AuthController, :saml_redirect)
+    get("/auth/saml_redirect_vscode", AuthController, :saml_redirect_vscode)
+    get("/auth/exchange", AuthController, :exchange)
   end
 
   scope "/v2", CadetWeb do

--- a/priv/repo/migrations/20250317093922_create_code_exchange_table.exs
+++ b/priv/repo/migrations/20250317093922_create_code_exchange_table.exs
@@ -1,0 +1,13 @@
+defmodule Cadet.Repo.Migrations.CreateCodeExchangeTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:code_exchange) do
+      add(:code, :string, null: false)
+      add(:generated_at, :utc_datetime_usec, null: false)
+      add(:expires_at, :utc_datetime_usec, null: false)
+      add(:user_id, references(:users), null: false)
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20250317093922_create_token_exchange_table.exs
+++ b/priv/repo/migrations/20250317093922_create_token_exchange_table.exs
@@ -1,8 +1,8 @@
-defmodule Cadet.Repo.Migrations.CreateCodeExchangeTable do
+defmodule Cadet.Repo.Migrations.CreateTokenExchangeTable do
   use Ecto.Migration
 
   def change do
-    create table(:code_exchange) do
+    create table(:token_exchange) do
       add(:code, :string, null: false)
       add(:generated_at, :utc_datetime_usec, null: false)
       add(:expires_at, :utc_datetime_usec, null: false)


### PR DESCRIPTION
FYP: Source Academy as Visual Studio Code Extension

The Visual Studio Code extension for Source Academy requires a slight change to the login flow.

# Idea
Here is the big picture of why this PR is needed, as well as why it is as such.

1. IFrames
    - Originally: After a normal SAML login, the backend redirects to the a frontend route (`/login/callback`)
    - Constraint: The NUS login page cannot be displayed within the VSC as an iframe, instead requiring login via external browser. From the backend's perspective, this means the login request is no longer the same device as the client.
    - Idea: Backend behaviour has to be modified to redirect to a VSC deeplink instead.

2. Security
    - Originally: After a normal SAML login, backend passes auth tokens to frontend indirectly via cookies.
    - Idea 1: Via query parameters in the deeplink, we pass auth tokens to VSC extension for it to pass it to the iframe frontend.
    - Constraint: We don't want the VSC extension to have knowledge of auth (access and refresh) tokens.
    - Final idea: Pass a temp token/code via the deeplink. The iframe frontend then uses temp token to exchange for the real auth tokens.

# Modified login flow for VSC
1. User runs the "Login" command from within VSC, opening a browser window

6. Normal SAML flow
    - Backend (service provider): `api.sourceacademy.nus.edu.sg/sso/auth/signin/student?target_url=<url in (3)>`
    - NUS (identity provider): `vafs.u.nus.edu`
    - Backend (service provider): `api.sourceacademy.nus.edu.sg/sso/sp/consume/...`
    - Backend redirects browser to another backend endpoint

7. New backend endpoints and behaviour
    - `api.sourceacademy.nus.edu.sg/auth/saml_redirect_vscode?provider=<provider>`
    - A random temp code is generated and stored into a new `token_exchange` table with 1 minute expiry
    - Server redirects user to a VSC deeplink, see `vscode_redirect_url_prefix` in app vars (`vscode://source-academy.source-academy/sso?code=<code>&provider=<provider>`)

8. User's VSC extension handles and opens the iframe
    - URL pointing to backend at `api.sourceacademy.nus.edu.sg/auth/exchange?code=<code>&provider=<provider>`
    - Server validates code against table before generated tokens (both access and refresh)
    - Server redirects user to a new frontend route `sourceacademy.nus.edu.sg/login/vscode_callback?access_token=<access_token>&refresh_token=<refresh_token>`. This route saves tokens into Redux store and redirects users to `/welcome`.