### PR TITLE
fix: Filter team formation list

### DIFF
--- a/lib/cadet/accounts/teams.ex
+++ b/lib/cadet/accounts/teams.ex
@@ -13,6 +13,26 @@ defmodule Cadet.Accounts.Teams do
   alias Cadet.Assessments.{Answer, Submission}
 
   @doc """
+  Returns all teams for a given course.
+
+  ## Parameters
+
+    * `course_id` - The ID of the course.
+
+  ## Returns
+
+  Returns a list of teams.
+
+  """
+  def all_teams_for_course(course_id) do
+    Team
+    |> join(:inner, [t], a in assoc(t, :assessment))
+    |> where([t, a], a.course_id == ^course_id)
+    |> Repo.all()
+    |> Repo.preload(assessment: [:config], team_members: [student: [:user]])
+  end
+
+  @doc """
   Creates a new team and assigns an assessment and team members to it.
 
   ## Parameters

--- a/lib/cadet_web/admin_controllers/admin_teams_controller.ex
+++ b/lib/cadet_web/admin_controllers/admin_teams_controller.ex
@@ -6,8 +6,10 @@ defmodule CadetWeb.AdminTeamsController do
   alias Cadet.Accounts.{Teams, Team}
 
   def index(conn, %{"course_id" => course_id}) do
+    teams = Teams.all_teams_for_course(course_id)
+
     team_formation_overviews =
-      Teams.all_teams_for_course(course_id)
+      teams
       |> Enum.map(&team_to_team_formation_overview/1)
 
     conn

--- a/lib/cadet_web/admin_controllers/admin_teams_controller.ex
+++ b/lib/cadet_web/admin_controllers/admin_teams_controller.ex
@@ -5,14 +5,9 @@ defmodule CadetWeb.AdminTeamsController do
 
   alias Cadet.Accounts.{Teams, Team}
 
-  def index(conn, _params) do
-    teams =
-      Team
-      |> Repo.all()
-      |> Repo.preload(assessment: [:config], team_members: [student: [:user]])
-
+  def index(conn, %{"course_id" => course_id}) do
     team_formation_overviews =
-      teams
+      Teams.all_teams_for_course(course_id)
       |> Enum.map(&team_to_team_formation_overview/1)
 
     conn


### PR DESCRIPTION
<img width="1787" alt="image" src="https://github.com/user-attachments/assets/27841b97-656b-4181-9036-4f9f9e8d407a" />

Team formation on the frontend shows all teams ever created even if not part of the course.