### PR TITLE
fix: reduce warnings when running tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -9,7 +9,7 @@ config :cadet, CadetWeb.Endpoint,
 config :cadet, environment: :test
 
 # Print only warnings and errors during test
-config :logger, level: :warn, compile_time_purge_matching: [[level_lower_than: :warn]]
+config :logger, level: :warning, compile_time_purge_matching: [[level_lower_than: :warning]]
 
 config :ex_aws,
   access_key_id: "hello",

--- a/lib/cadet/accounts/teams.ex
+++ b/lib/cadet/accounts/teams.ex
@@ -64,7 +64,7 @@ defmodule Cadet.Accounts.Teams do
 
       true ->
         Enum.reduce_while(attrs["student_ids"], {:ok, nil}, fn team_attrs, {:ok, _} ->
-          student_ids = Enum.map(team_attrs, &Map.get(&1, "userId"))
+          _student_ids = Enum.map(team_attrs, &Map.get(&1, "userId"))
 
           {:ok, team} =
             %Team{}
@@ -105,7 +105,7 @@ defmodule Cadet.Accounts.Teams do
       ids = Enum.map(team, &Map.get(&1, "userId"))
 
       unique_ids_count = ids |> Enum.uniq() |> Enum.count()
-      all_ids_distinct = unique_ids_count == Enum.count(ids)
+      _all_ids_distinct = unique_ids_count == Enum.count(ids)
 
       student_already_in_team?(-1, ids, assessment_id)
     end)
@@ -229,7 +229,7 @@ defmodule Cadet.Accounts.Teams do
 
   """
   def update_team(team = %Team{}, new_assessment_id, student_ids) do
-    old_assessment_id = team.assessment_id
+    _old_assessment_id = team.assessment_id
     team_id = team.id
     new_student_ids = Enum.map(hd(student_ids), fn student -> Map.get(student, "userId") end)
 

--- a/lib/cadet/accounts/teams.ex
+++ b/lib/cadet/accounts/teams.ex
@@ -64,8 +64,6 @@ defmodule Cadet.Accounts.Teams do
 
       true ->
         Enum.reduce_while(attrs["student_ids"], {:ok, nil}, fn team_attrs, {:ok, _} ->
-          _student_ids = Enum.map(team_attrs, &Map.get(&1, "userId"))
-
           {:ok, team} =
             %Team{}
             |> Team.changeset(attrs)
@@ -105,7 +103,6 @@ defmodule Cadet.Accounts.Teams do
       ids = Enum.map(team, &Map.get(&1, "userId"))
 
       unique_ids_count = ids |> Enum.uniq() |> Enum.count()
-      _all_ids_distinct = unique_ids_count == Enum.count(ids)
 
       student_already_in_team?(-1, ids, assessment_id)
     end)
@@ -229,7 +226,6 @@ defmodule Cadet.Accounts.Teams do
 
   """
   def update_team(team = %Team{}, new_assessment_id, student_ids) do
-    _old_assessment_id = team.assessment_id
     team_id = team.id
     new_student_ids = Enum.map(hd(student_ids), fn student -> Map.get(student, "userId") end)
 

--- a/lib/cadet/assessments/question_types/mcq_question.ex
+++ b/lib/cadet/assessments/question_types/mcq_question.ex
@@ -20,7 +20,7 @@ defmodule Cadet.Assessments.QuestionTypes.MCQQuestion do
     |> cast(params, @required_fields)
     |> cast_embed(:choices, with: &MCQChoice.changeset/2, required: true)
     |> validate_one_correct_answer
-    |> validate_required(@required_fields)
+    |> validate_required(@required_fields ++ ~w(choices)a)
   end
 
   defp validate_one_correct_answer(changeset) do

--- a/lib/cadet/assessments/question_types/mcq_question.ex
+++ b/lib/cadet/assessments/question_types/mcq_question.ex
@@ -20,7 +20,7 @@ defmodule Cadet.Assessments.QuestionTypes.MCQQuestion do
     |> cast(params, @required_fields)
     |> cast_embed(:choices, with: &MCQChoice.changeset/2, required: true)
     |> validate_one_correct_answer
-    |> validate_required(@required_fields ++ ~w(choices)a)
+    |> validate_required(@required_fields)
   end
 
   defp validate_one_correct_answer(changeset) do

--- a/lib/cadet/devices/devices.ex
+++ b/lib/cadet/devices/devices.ex
@@ -212,7 +212,7 @@ defmodule Cadet.Devices do
               },
               300,
               [],
-              ''
+              ""
             )
 
           # ExAws includes the session token in the signed payload and doesn't allow

--- a/lib/cadet/jobs/autograder/lambda_worker.ex
+++ b/lib/cadet/jobs/autograder/lambda_worker.ex
@@ -21,7 +21,7 @@ defmodule Cadet.Autograder.LambdaWorker do
     lambda_params = build_request_params(params)
 
     if Enum.empty?(lambda_params.testcases) do
-      Logger.warn("No testcases found. Skipping autograding for answer_id: #{answer.id}")
+      Logger.warning("No testcases found. Skipping autograding for answer_id: #{answer.id}")
       # Fix for https://github.com/source-academy/backend/issues/472
       Process.sleep(1000)
     else

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -34,7 +34,7 @@ defmodule Cadet.Updater.XMLParser do
       :ok
     else
       {:error, stage, %{errors: [assessment: {"has submissions", []}]}, _} when is_atom(stage) ->
-        Logger.warn("Assessment has submissions, ignoring...")
+        Logger.warning("Assessment has submissions, ignoring...")
         {:ok, "Assessment has submissions, ignoring..."}
 
       {:error, error_message} ->

--- a/lib/cadet/notifications.ex
+++ b/lib/cadet/notifications.ex
@@ -276,15 +276,15 @@ defmodule Cadet.Notifications do
     |> Repo.insert()
   end
 
-  @doc """
-  Returns the list of sent_notifications.
+  # @doc """
+  # Returns the list of sent_notifications.
 
-  ## Examples
+  # ## Examples
 
-      iex> list_sent_notifications()
-      [%SentNotification{}, ...]
+  #    iex> list_sent_notifications()
+  #    [%SentNotification{}, ...]
 
-  """
+  # """
 
   # def list_sent_notifications do
   #   Repo.all(SentNotification)

--- a/lib/cadet_web/admin_controllers/admin_stories_controller.ex
+++ b/lib/cadet_web/admin_controllers/admin_stories_controller.ex
@@ -12,7 +12,7 @@ defmodule CadetWeb.AdminStoriesController do
 
     case result do
       {:ok, _story} ->
-        conn |> put_status(200) |> text('')
+        conn |> put_status(200) |> text("")
 
       {:error, {status, message}} ->
         conn
@@ -29,7 +29,7 @@ defmodule CadetWeb.AdminStoriesController do
 
     case result do
       {:ok, _story} ->
-        conn |> put_status(200) |> text('')
+        conn |> put_status(200) |> text("")
 
       {:error, {status, message}} ->
         conn
@@ -43,7 +43,7 @@ defmodule CadetWeb.AdminStoriesController do
 
     case result do
       {:ok, _nil} ->
-        conn |> put_status(204) |> text('')
+        conn |> put_status(204) |> text("")
 
       {:error, {status, message}} ->
         conn

--- a/lib/cadet_web/controllers/answer_controller.ex
+++ b/lib/cadet_web/controllers/answer_controller.ex
@@ -38,6 +38,10 @@ defmodule CadetWeb.AnswerController do
     end
   end
 
+  def submit(conn, _params) do
+    send_resp(conn, :bad_request, "Missing or invalid parameter(s)")
+  end
+
   def check_last_modified(conn, %{
         "questionid" => question_id,
         "lastModifiedAt" => last_modified_at
@@ -77,10 +81,6 @@ defmodule CadetWeb.AnswerController do
         |> put_status(:forbidden)
         |> text("Forbidden")
     end
-  end
-
-  def submit(conn, _params) do
-    send_resp(conn, :bad_request, "Missing or invalid parameter(s)")
   end
 
   swagger_path :submit do

--- a/test/cadet/assessments/assessments_test.exs
+++ b/test/cadet/assessments/assessments_test.exs
@@ -3142,7 +3142,7 @@ defmodule Cadet.AssessmentsTest do
 
   defp expected_top_relative_scores(top_x, token_divider) do
     # "return 0;" in the factory has 3 token
-    10..0
+    10..0//-1
     |> Enum.to_list()
     |> Enum.map(fn score -> 10 * score - :math.pow(2, 3 / token_divider) end)
     |> Enum.take(top_x)

--- a/test/cadet/assessments/assessments_test.exs
+++ b/test/cadet/assessments/assessments_test.exs
@@ -2223,7 +2223,7 @@ defmodule Cadet.AssessmentsTest do
 
     test "limit submisssions 2", %{
       course_regs: %{avenger1_cr: avenger},
-      assessments: assessments
+      assessments: _assessments
     } do
       {_, res} =
         Assessments.submissions_by_grader_for_index(avenger, %{

--- a/test/cadet_web/admin_controllers/admin_assessments_controller_test.exs
+++ b/test/cadet_web/admin_controllers/admin_assessments_controller_test.exs
@@ -5,7 +5,7 @@ defmodule CadetWeb.AdminAssessmentsControllerTest do
   import Ecto.Query
   import ExUnit.CaptureLog
 
-  alias Cadet.{Assessments, Repo}
+  alias Cadet.Repo
   alias Cadet.Accounts.CourseRegistration
   alias Cadet.Assessments.{Assessment, Submission}
   alias Cadet.Test.XMLGenerator

--- a/test/cadet_web/plug/rate_limiter_test.exs
+++ b/test/cadet_web/plug/rate_limiter_test.exs
@@ -22,8 +22,6 @@ defmodule CadetWeb.Plugs.RateLimiterTest do
   end
 
   test "rate limit exceeded", %{conn: conn} do
-    _ = "user:1"
-
     # Simulate exceeding the rate limit
     for _ <- 1..RateLimiter.rate_limit() do
       conn = RateLimiter.call(conn, %{})

--- a/test/cadet_web/plug/rate_limiter_test.exs
+++ b/test/cadet_web/plug/rate_limiter_test.exs
@@ -22,7 +22,7 @@ defmodule CadetWeb.Plugs.RateLimiterTest do
   end
 
   test "rate limit exceeded", %{conn: conn} do
-    key = "user:1"
+    _ = "user:1"
 
     # Simulate exceeding the rate limit
     for _ <- 1..RateLimiter.rate_limit() do


### PR DESCRIPTION
Tried to reduce the number of warnings emitted when running `mix test`. There are still some warnings left, reasons for which are not fixed mainly below to the following two categories:
1. Warning is about a deprecated API of a library, and changing requires better understanding of the library (which I don't have)
2. Cause of warning is directly from a library, and a possible way to remove warning is to upgrade the library.