### PR TITLE
test(assessments): fix flaky title-sort tests via DB collation

### DIFF
--- a/test/cadet/assessments/assessments_test.exs
+++ b/test/cadet/assessments/assessments_test.exs
@@ -2863,13 +2863,9 @@ defmodule Cadet.AssessmentsTest do
           end
         )
 
-      Enum.reduce(
-        submissions_by_title,
-        fn x, y ->
-          assert x.title >= y.title
-          y
-        end
-      )
+      submissions_by_title
+      |> Enum.map(& &1.title)
+      |> assert_sorted_by_db_collation(:asc)
     end
 
     test "sorting by assessment title descending", %{
@@ -2897,13 +2893,9 @@ defmodule Cadet.AssessmentsTest do
           end
         )
 
-      Enum.reduce(
-        submissions_by_title,
-        fn x, y ->
-          assert x.title <= y.title
-          y
-        end
-      )
+      submissions_by_title
+      |> Enum.map(& &1.title)
+      |> assert_sorted_by_db_collation(:desc)
     end
 
     test "sorting by assessment type ascending", %{
@@ -3387,5 +3379,27 @@ defmodule Cadet.AssessmentsTest do
   defp get_all_student_xp(all_users) do
     all_users.users
     |> Enum.map(fn user -> user.total_xp end)
+  end
+
+  # submissions_by_grader_for_index sorts titles with `upper(title)` in the
+  # database, which uses PostgreSQL's locale collation. That ordering does not
+  # match Elixir's binary string comparison (e.g. they disagree on how spaces
+  # and punctuation sort relative to letters), so comparing the returned titles
+  # with Elixir's `<=`/`>=` is flaky against the randomly generated titles.
+  # Instead, assert the returned order matches how the database itself sorts the
+  # same titles, comparing `upper(title)` on both sides for a stable check.
+  defp assert_sorted_by_db_collation(titles, direction) when direction in [:asc, :desc] do
+    %{rows: [[returned, expected]]} =
+      Repo.query!(
+        """
+        SELECT
+          array_agg(upper(t) ORDER BY ord),
+          array_agg(upper(t) ORDER BY upper(t) #{direction})
+        FROM unnest($1::text[]) WITH ORDINALITY AS x(t, ord)
+        """,
+        [titles]
+      )
+
+    assert returned == expected
   end
 end


### PR DESCRIPTION
## Problem

The `submissions_by_grader_for_index` title-sort tests are flaky. On PR #1377's CI they failed with:

```
Assertion with >= failed
code:  assert x.title >= y.title
left:  "I will speak daggers to her, but use none."
right: "In my mind's eye."
```

## Root cause

The query sorts by `upper(title)` in the database, which uses PostgreSQL's **locale collation**:

```elixir
order_by: [{^sort_direction, fragment("upper(?)", asst.title)}]
```

The tests then re-checked the returned order with Elixir's **binary** string comparison (`assert x.title >= y.title`). The two disagree on how spaces and punctuation sort relative to letters — e.g. PostgreSQL's collation orders `"In my mind's eye."` before `"I will speak daggers to her, but use none."` (ignoring the space), whereas Elixir's binary comparison does the opposite (space `0x20` < `n`).

Assessment titles are randomly generated Hamlet quotes (`Faker.Lorem.Shakespeare.En.hamlet()`), and Faker is not seeded, so whenever a run happened to produce two titles straddling this boundary, the test failed. Only the **title** sort tests are affected (type/xp sort by integers). `String.upcase/1` alone would not fix it — the failing pair are both already uppercase-initial.

## Fix

Assert the returned order against the **database's own sort** of the same titles, comparing `upper(title)` on both sides. This makes the check deterministic and consistent with the query under any collation, and it now verifies the full ordering rather than only that the first element is the extremum.

Verified locally: the helper passes for the DB-correct order (which the old binary check would have wrongly rejected) and fails for a reversed order. Ran the two tests across multiple random seeds and the full `assessments_test.exs` (90 tests) — all green.

## Note

Stacked on #1377 (`fix-course-creation-500`) since it is unrelated to that course-creation fix. GitHub will retarget this PR to `master` once #1377 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)