### PR TITLE
Add support for python autograder runtime

### DIFF
--- a/config/cadet.exs.example
+++ b/config/cadet.exs.example
@@ -101,10 +101,9 @@ config :cadet,
   #     scope: "openid profile"
   #   ]
   # ],
+  # python lambda required for python grading runtime
   autograder: [
     lambda_name: "<unique-identifier>-grader",
-    # Invoked for questions with runtime "python". If omitted, such questions
-    # fail gracefully rather than being graded by the legacy interpreter.
     python_lambda_name: "<unique-identifier>-python-grader"
   ],
   uploader: [

--- a/config/cadet.exs.example
+++ b/config/cadet.exs.example
@@ -102,7 +102,10 @@ config :cadet,
   #   ]
   # ],
   autograder: [
-    lambda_name: "<unique-identifier>-grader"
+    lambda_name: "<unique-identifier>-grader",
+    # Invoked for questions with runtime "python". If omitted, such questions
+    # fail gracefully rather than being graded by the legacy interpreter.
+    python_lambda_name: "<unique-identifier>-python-grader"
   ],
   uploader: [
     assets_bucket: "<unique-identifier>-assets",

--- a/config/dev.secrets.exs.example
+++ b/config/dev.secrets.exs.example
@@ -77,7 +77,8 @@ config :cadet,
   #   ]
   # ],
   autograder: [
-    lambda_name: "autograderLambdaName"
+    lambda_name: "autograderLambdaName",
+    python_lambda_name: "pythonAutograderLambdaName"
   ],
   uploader: [
     assets_bucket: "source-academy-assets",

--- a/config/test.exs
+++ b/config/test.exs
@@ -77,7 +77,8 @@ config :cadet,
        }}
   },
   autograder: [
-    lambda_name: "dummy"
+    lambda_name: "dummy",
+    python_lambda_name: "dummy-python"
   ],
   uploader: [
     assets_bucket: "test-sa-assets",

--- a/lib/cadet/assessments/library.ex
+++ b/lib/cadet/assessments/library.ex
@@ -13,7 +13,7 @@ defmodule Cadet.Assessments.Library do
     field(:exec_time_ms, :integer, default: 1000)
     field(:globals, :map, default: %{})
     field(:language_options, :map, default: %{})
-    field(:runtime, :string, default: "legacy")
+    field(:runtime, :string, default: "python")
     embeds_one(:external, ExternalLibrary, on_replace: :update)
   end
 

--- a/lib/cadet/assessments/library.ex
+++ b/lib/cadet/assessments/library.ex
@@ -13,11 +13,12 @@ defmodule Cadet.Assessments.Library do
     field(:exec_time_ms, :integer, default: 1000)
     field(:globals, :map, default: %{})
     field(:language_options, :map, default: %{})
+    field(:runtime, :string, default: "legacy")
     embeds_one(:external, ExternalLibrary, on_replace: :update)
   end
 
   @required_fields ~w(chapter)a
-  @optional_fields ~w(globals variant language_options exec_time_ms)a
+  @optional_fields ~w(globals variant language_options exec_time_ms runtime)a
   @required_embeds ~w(external)a
 
   def changeset(library, params \\ %{}) do

--- a/lib/cadet/jobs/autograder/lambda_worker.ex
+++ b/lib/cadet/jobs/autograder/lambda_worker.ex
@@ -53,10 +53,15 @@ defmodule Cadet.Autograder.LambdaWorker do
       Process.sleep(1000)
       :ok
     else
+      config = Application.fetch_env!(:cadet, :autograder)
+      runtime = resolve_runtime(question.grading_library.runtime)
+
+      lambda_name =
+        Keyword.get(config, lambda_key_for(runtime)) ||
+          raise "No autograder lambda configured for runtime #{inspect(runtime)}"
+
       response =
-        :cadet
-        |> Application.fetch_env!(:autograder)
-        |> Keyword.get(:lambda_name)
+        lambda_name
         |> ExAws.Lambda.invoke(lambda_params, %{})
         |> ExAws.request!()
 
@@ -71,6 +76,13 @@ defmodule Cadet.Autograder.LambdaWorker do
       :ok
     end
   end
+
+  # might want to check if this is actually needed
+  defp resolve_runtime(runtime) when runtime in [nil, ""], do: "legacy"
+  defp resolve_runtime(runtime), do: runtime
+
+  defp lambda_key_for("legacy"), do: :lambda_name
+  defp lambda_key_for("python"), do: :python_lambda_name
 
   defp enqueue_result_store(args) do
     args
@@ -144,7 +156,8 @@ defmodule Cadet.Autograder.LambdaWorker do
       library: %{
         chapter: question.grading_library.chapter,
         external: upcased_name_external,
-        globals: Enum.map(question.grading_library.globals, fn {k, v} -> [k, v] end)
+        globals: Enum.map(question.grading_library.globals, fn {k, v} -> [k, v] end),
+        runtime: question.grading_library.runtime
       }
     }
   end

--- a/lib/cadet/jobs/autograder/lambda_worker.ex
+++ b/lib/cadet/jobs/autograder/lambda_worker.ex
@@ -78,7 +78,7 @@ defmodule Cadet.Autograder.LambdaWorker do
   end
 
   # might want to check if this is actually needed
-  defp resolve_runtime(runtime) when runtime in [nil, ""], do: "legacy"
+  defp resolve_runtime(runtime) when runtime in [nil, ""], do: "python"
   defp resolve_runtime(runtime), do: runtime
 
   defp lambda_key_for("legacy"), do: :lambda_name

--- a/lib/cadet/jobs/xml_parser.ex
+++ b/lib/cadet/jobs/xml_parser.ex
@@ -287,15 +287,20 @@ defmodule Cadet.Updater.XMLParser do
         library
 
     if library do
-      question
-      |> Map.put(:library, parse_programming_language(library))
-      |> Map.put(:grading_library, parse_programming_language(grading_library))
+      with {:ok, parsed_library} <- parse_programming_language(library),
+           {:ok, parsed_grading_library} <- parse_programming_language(grading_library) do
+        question
+        |> Map.put(:library, parsed_library)
+        |> Map.put(:grading_library, parsed_grading_library)
+      end
     else
       {:error, "Missing PROGRAMMINGLANGUAGE"}
     end
   end
 
-  @spec parse_programming_language(any()) :: map()
+  @valid_runtimes ~w(legacy python)
+
+  @spec parse_programming_language(any()) :: {:ok, map()} | {:error, String.t()}
   defp parse_programming_language(library_entity) do
     globals =
       library_entity
@@ -323,17 +328,31 @@ defmodule Cadet.Updater.XMLParser do
     options_map =
       options_list |> Map.new(&{&1.key, &1.value})
 
-    library_entity
-    |> xpath(
-      ~x"."e,
-      chapter: ~x"./@interpreter"i,
-      exec_time_ms: ~x"./@exectime"oi,
-      variant: ~x"./@variant"os
-    )
-    |> Map.put(:globals, globals)
-    |> Map.put(:external, external)
-    |> Map.put(:language_options, options_map)
+    parsed =
+      library_entity
+      |> xpath(
+        ~x"."e,
+        chapter: ~x"./@interpreter"i,
+        exec_time_ms: ~x"./@exectime"oi,
+        variant: ~x"./@variant"os,
+        runtime: ~x"./@runtime"os
+      )
+      |> Map.put(:globals, globals)
+      |> Map.put(:external, external)
+      |> Map.put(:language_options, options_map)
+
+    case validate_runtime(parsed.runtime) do
+      {:ok, runtime} -> {:ok, put_runtime(parsed, runtime)}
+      error -> error
+    end
   end
+
+  defp validate_runtime(""), do: {:ok, nil}
+  defp validate_runtime(runtime) when runtime in @valid_runtimes, do: {:ok, runtime}
+  defp validate_runtime(runtime), do: {:error, "Invalid runtime #{inspect(runtime)}"}
+
+  defp put_runtime(parsed, nil), do: Map.delete(parsed, :runtime)
+  defp put_runtime(parsed, runtime), do: Map.put(parsed, :runtime, runtime)
 
   @spec process_charlist(charlist() | nil) :: String.t() | nil
 

--- a/lib/cadet_web/helpers/assessments_helpers.ex
+++ b/lib/cadet_web/helpers/assessments_helpers.ex
@@ -11,7 +11,8 @@ defmodule CadetWeb.AssessmentsHelpers do
       execTimeMs: :exec_time_ms,
       globals: :globals,
       external: &build_external_library(%{external_library: &1.external}),
-      languageOptions: :language_options
+      languageOptions: :language_options,
+      runtime: :runtime
     })
   end
 

--- a/test/cadet/assessments/library_test.exs
+++ b/test/cadet/assessments/library_test.exs
@@ -109,13 +109,13 @@ defmodule Cadet.Assessments.LibraryTest do
       |> assert_changeset(:valid)
     end
 
-    test "runtime defaults to legacy", %{valid_params: params} do
+    test "runtime defaults to python", %{valid_params: params} do
       library =
         %Library{}
         |> Library.changeset(params)
         |> Ecto.Changeset.apply_changes()
 
-      assert library.runtime == "legacy"
+      assert library.runtime == "python"
     end
   end
 end

--- a/test/cadet/assessments/library_test.exs
+++ b/test/cadet/assessments/library_test.exs
@@ -102,5 +102,20 @@ defmodule Cadet.Assessments.LibraryTest do
       |> Map.delete(:external)
       |> assert_changeset(:valid)
     end
+
+    test "valid changeset with runtime", %{valid_params: params} do
+      params
+      |> Map.put(:runtime, "python")
+      |> assert_changeset(:valid)
+    end
+
+    test "runtime defaults to legacy", %{valid_params: params} do
+      library =
+        %Library{}
+        |> Library.changeset(params)
+        |> Ecto.Changeset.apply_changes()
+
+      assert library.runtime == "legacy"
+    end
   end
 end

--- a/test/cadet/jobs/autograder/lambda_worker_test.exs
+++ b/test/cadet/jobs/autograder/lambda_worker_test.exs
@@ -261,7 +261,8 @@ defmodule Cadet.Autograder.LambdaWorkerTest do
             name: question.grading_library.external.name |> String.upcase(),
             symbols: question.grading_library.external.symbols
           },
-          globals: Enum.map(question.grading_library.globals, fn {k, v} -> [k, v] end)
+          globals: Enum.map(question.grading_library.globals, fn {k, v} -> [k, v] end),
+          runtime: question.grading_library.runtime
         }
       }
 
@@ -269,6 +270,115 @@ defmodule Cadet.Autograder.LambdaWorkerTest do
                question: Repo.get(Question, question.id),
                answer: Repo.get(Answer, answer.id)
              }) == expected
+    end
+
+    test "it passes the python runtime through to the grader", %{answer: answer} do
+      question =
+        insert(:programming_question, %{grading_library: build(:library, %{runtime: "python"})})
+
+      params =
+        LambdaWorker.build_request_params(%{
+          question: Repo.get(Question, question.id),
+          answer: Repo.get(Answer, answer.id)
+        })
+
+      assert params.library.runtime == "python"
+    end
+  end
+
+  describe "runtime routing" do
+    setup %{answer: answer} do
+      python_question =
+        insert(:programming_question, %{
+          grading_library: build(:library, %{runtime: "python"}),
+          question:
+            build(:programming_question_content, %{
+              public: [%{"score" => 1, "answer" => "1", "program" => "f(1);"}],
+              opaque: [],
+              secret: []
+            })
+        })
+
+      python_answer =
+        insert(:answer, %{
+          submission:
+            insert(:submission, %{
+              student: insert(:course_registration, %{role: :student}),
+              assessment: python_question.assessment
+            }),
+          question: python_question,
+          answer: %{code: "1"}
+        })
+
+      %{python_question: python_question, python_answer: python_answer, answer: answer}
+    end
+
+    test "python questions invoke the configured python lambda", %{python_answer: python_answer} do
+      with_testing_mode(:manual, fn ->
+        with_mocks [
+          {ExAws.Lambda, [:passthrough],
+           invoke: fn lambda_name, _params, _opts ->
+             send(self(), {:invoked_lambda, lambda_name})
+             %{stub: lambda_name}
+           end},
+          {ExAws, [:passthrough],
+           request!: fn _request -> %{"totalScore" => 0, "maxScore" => 0, "results" => []} end}
+        ] do
+          LambdaWorker.perform(%{
+            question_id: python_answer.question_id,
+            answer_id: python_answer.id
+          })
+
+          assert_received {:invoked_lambda, "dummy-python"}
+        end
+      end)
+    end
+
+    test "python questions fail gracefully when no python lambda is configured", %{
+      python_answer: python_answer
+    } do
+      original = Application.fetch_env!(:cadet, :autograder)
+      on_exit(fn -> Application.put_env(:cadet, :autograder, original) end)
+      Application.put_env(:cadet, :autograder, Keyword.delete(original, :python_lambda_name))
+
+      with_testing_mode(:manual, fn ->
+        log =
+          capture_log(fn ->
+            assert {:error, _} =
+                     LambdaWorker.perform(%Oban.Job{
+                       args: %{
+                         "question_id" => python_answer.question_id,
+                         "answer_id" => python_answer.id
+                       }
+                     })
+          end)
+
+        assert log =~ "No autograder lambda configured for runtime \"python\""
+
+        assert_enqueued(
+          worker: ResultStoreWorker,
+          args: %{
+            answer_id: python_answer.id,
+            result: %{
+              score: 0,
+              max_score: 1,
+              status: :failed,
+              result: [
+                %{
+                  "resultType" => "error",
+                  "errors" => [
+                    %{
+                      "errorType" => "systemError",
+                      "errorMessage" =>
+                        "Autograder runtime error. Please contact a system administrator"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        )
+      end)
     end
   end
 end

--- a/test/cadet/updater/xml_parser_test.exs
+++ b/test/cadet/updater/xml_parser_test.exs
@@ -277,6 +277,42 @@ defmodule Cadet.Updater.XMLParserTest do
     end
   end
 
+  describe "runtime parsing" do
+    setup %{course: course, assessments_with_config: assessments_with_config} do
+      [{assessment, assessment_config} | _] = Enum.to_list(assessments_with_config)
+      %{course: course, assessment: assessment, assessment_config: assessment_config}
+    end
+
+    test "parses the grading library runtime", context do
+      question =
+        build(:programming_question, grading_library: build(:library, %{runtime: "python"}))
+
+      assert parse_single_question(context, question).grading_library.runtime == "python"
+    end
+
+    test "defaults to legacy when the runtime attribute is absent", context do
+      question = build(:programming_question, grading_library: build(:library))
+
+      assert parse_single_question(context, question).grading_library.runtime == "legacy"
+    end
+
+    test "rejects an unknown runtime", %{
+      course: course,
+      assessment: assessment,
+      assessment_config: assessment_config
+    } do
+      question =
+        build(:programming_question, grading_library: build(:library, %{runtime: "haskell"}))
+
+      xml = XMLGenerator.generate_xml_for(assessment, [question])
+
+      assert capture_log(fn ->
+               assert XMLParser.parse_xml(xml, course.id, assessment_config.id) ==
+                        {:error, {:bad_request, "Invalid runtime \"haskell\""}}
+             end) =~ "Invalid runtime \"haskell\""
+    end
+  end
+
   describe "XML file processing" do
     test "happy path", %{
       questions: questions,
@@ -359,6 +395,18 @@ defmodule Cadet.Updater.XMLParserTest do
           assert(map1[key] == map2[key], assert_error_message)
       end
     end
+  end
+
+  defp parse_single_question(
+         %{course: course, assessment: assessment, assessment_config: assessment_config},
+         question
+       ) do
+    xml = XMLGenerator.generate_xml_for(assessment, [question])
+
+    assert XMLParser.parse_xml(xml, course.id, assessment_config.id) == :ok
+
+    assessment_db = Repo.get_by!(Assessment, number: assessment.number)
+    Repo.one!(where(Question, assessment_id: ^assessment_db.id))
   end
 
   defp convert_map_keys_to_string(struct = %{__struct__: _}) do

--- a/test/cadet/updater/xml_parser_test.exs
+++ b/test/cadet/updater/xml_parser_test.exs
@@ -290,10 +290,10 @@ defmodule Cadet.Updater.XMLParserTest do
       assert parse_single_question(context, question).grading_library.runtime == "python"
     end
 
-    test "defaults to legacy when the runtime attribute is absent", context do
+    test "defaults to python when the runtime attribute is absent", context do
       question = build(:programming_question, grading_library: build(:library))
 
-      assert parse_single_question(context, question).grading_library.runtime == "legacy"
+      assert parse_single_question(context, question).grading_library.runtime == "python"
     end
 
     test "rejects an unknown runtime", %{

--- a/test/cadet_web/admin_controllers/admin_grading_controller_test.exs
+++ b/test/cadet_web/admin_controllers/admin_grading_controller_test.exs
@@ -310,7 +310,8 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
-                      "variant" => &1.question.library.variant
+                      "variant" => &1.question.library.variant,
+                      "runtime" => &1.question.library.runtime
                     },
                     "maxXp" => &1.question.max_xp,
                     "content" => &1.question.question.content,
@@ -355,7 +356,8 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
-                      "variant" => &1.question.library.variant
+                      "variant" => &1.question.library.variant,
+                      "runtime" => &1.question.library.runtime
                     },
                     "maxXp" => &1.question.max_xp,
                     "content" => &1.question.question.content,
@@ -410,7 +412,8 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
-                      "variant" => &1.question.library.variant
+                      "variant" => &1.question.library.variant,
+                      "runtime" => &1.question.library.runtime
                     },
                     "maxXp" => &1.question.max_xp,
                     "content" => &1.question.question.content,
@@ -1344,7 +1347,8 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
-                      "variant" => &1.question.library.variant
+                      "variant" => &1.question.library.variant,
+                      "runtime" => &1.question.library.runtime
                     },
                     "maxXp" => &1.question.max_xp,
                     "content" => &1.question.question.content,
@@ -1389,7 +1393,8 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
-                      "variant" => &1.question.library.variant
+                      "variant" => &1.question.library.variant,
+                      "runtime" => &1.question.library.runtime
                     },
                     "content" => &1.question.question.content,
                     "answer" => &1.answer.choice_id,
@@ -1444,7 +1449,8 @@ defmodule CadetWeb.AdminGradingControllerTest do
                       },
                       "execTimeMs" => &1.question.library.exec_time_ms,
                       "languageOptions" => %{},
-                      "variant" => &1.question.library.variant
+                      "variant" => &1.question.library.variant,
+                      "runtime" => &1.question.library.runtime
                     },
                     "maxXp" => &1.question.max_xp,
                     "content" => &1.question.question.content,

--- a/test/support/xml_generator.ex
+++ b/test/support/xml_generator.ex
@@ -175,11 +175,11 @@ defmodule Cadet.Test.XMLGenerator do
   end
 
   defp programminglanguage(raw_attrs, children) do
-    {"PROGRAMMINGLANGUAGE", map_permit_keys(raw_attrs, ~w(interpreter)a), children}
+    {"PROGRAMMINGLANGUAGE", map_permit_keys(raw_attrs, ~w(interpreter runtime)a), children}
   end
 
   defp graderprogramminglanguage(raw_attrs, children) do
-    {"GRADERPROGRAMMINGLANGUAGE", map_permit_keys(raw_attrs, ~w(interpreter)a), children}
+    {"GRADERPROGRAMMINGLANGUAGE", map_permit_keys(raw_attrs, ~w(interpreter runtime)a), children}
   end
 
   defp external(raw_attrs, children) do
@@ -213,7 +213,7 @@ defmodule Cadet.Test.XMLGenerator do
     else
       [
         tag_function.(
-          %{interpreter: library.chapter},
+          %{interpreter: library.chapter, runtime: library[:runtime]},
           [
             external(
               %{name: library.external.name},


### PR DESCRIPTION
This PR allows assessments to choose between which runtime to run the autograder for. This is implemented as a new field in the XML assessment file under library configuration. 

The supported runtimes are:
- `legacy` - old, Source/Javascript based runtime
- `python` - python runtime which using py-slang py2js

In future, the `conductor` runtime can be added to support all languages and features of conductor. Other fields such as `variant` can be used to choose the particular conductor runtime (TBD on how this will actually work).

Also added some tests to validate the behaviour of choosing runtime as well as XML parsing of the runtime.